### PR TITLE
docs: update README to reflect current algorithm and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@ Generate beautiful, deterministic abstract art from git commit hashes. Perfect f
 
 ## Features
 
-- Generate consistent, deterministic abstract art from any git hash
-- Configurable canvas sizes and output formats
-- Built-in presets for common social media and device sizes
-- Harmonious color schemes based on hash values
-- Grid-based composition system for balanced layouts
-- Multiple shape types and layering effects
-- Customizable output settings
+- Deterministic output — same hash always produces the same image
+- Hash-derived harmonious color schemes (analogic, complementary, and triadic palettes)
+- 20+ shape types across three categories: basic, complex, and sacred geometry
+- Layered composition with depth — early layers use simple shapes, later layers use intricate ones
+- Focal point composition — hash-derived attractors create intentional-looking layouts
+- Watercolor-style transparency with semi-transparent fills and color blending
+- Glow effects on sacred geometry shapes for an ethereal quality
+- Radial gradient fills and organic color jitter for a hand-painted feel
+- Organic bezier curves connecting nearby shapes
+- Configurable canvas size, layers, shape sizes, and opacity
+- Built-in presets for social media, device wallpapers, and print sizes
+- CLI for generating art from the current commit or a specific hash
 
 ## Installation
 
@@ -21,84 +26,90 @@ npm install git-hash-art
 ## Basic Usage
 
 ```javascript
-import { generateImageFromHash } from 'git-hash-art';
+import { generateImageFromHash, saveImageToFile } from 'git-hash-art';
 
-// Generate art from a git hash with default settings
+// Generate a PNG buffer from a git hash
 const gitHash = '46192e59d42f741c761cbea79462a8b3815dd905';
-generateImageFromHash(gitHash);
+const imageBuffer = generateImageFromHash(gitHash);
+
+// Save to disk
+saveImageToFile(imageBuffer, './output', gitHash, 'my-art', 2048, 2048);
 ```
 
 ## Advanced Usage
 
 ```javascript
-// Custom configuration
 const config = {
   width: 1920,
   height: 1080,
   gridSize: 6,
-  layers: 7,
-  shapesPerLayer: 30,
+  layers: 5,
+  shapesPerLayer: 40,
   minShapeSize: 20,
-  maxShapeSize: 180,
-  baseOpacity: 0.6,
-  opacityReduction: 0.1
+  maxShapeSize: 300,
+  baseOpacity: 0.7,
+  opacityReduction: 0.12
 };
 
-generateImageFromHash(gitHash, config);
+const imageBuffer = generateImageFromHash(gitHash, config);
 ```
 
 ## Configuration Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `width` | number | 1024 | Canvas width in pixels |
-| `height` | number | 1024 | Canvas height in pixels |
-| `gridSize` | number | 4 | Number of grid cells (gridSize x gridSize) |
-| `layers` | number | 5 | Number of layers to generate |
-| `shapesPerLayer` | number | - | Base number of shapes per layer (defaults to grid cells * 1.5) |
-| `minShapeSize` | number | 20 | Minimum shape size |
-| `maxShapeSize` | number | 180 | Maximum shape size |
-| `baseOpacity` | number | 0.6 | Starting opacity for first layer |
-| `opacityReduction` | number | 0.1 | How much to reduce opacity per layer |
+| `width` | number | 2048 | Canvas width in pixels |
+| `height` | number | 2048 | Canvas height in pixels |
+| `gridSize` | number | 5 | Controls base shape count per layer (gridSize² × 1.5) |
+| `layers` | number | 4 | Number of layers to generate |
+| `shapesPerLayer` | number | auto | Base shapes per layer (defaults to gridSize² × 1.5) |
+| `minShapeSize` | number | 30 | Minimum shape size in pixels (scaled to canvas) |
+| `maxShapeSize` | number | 400 | Maximum shape size in pixels (scaled to canvas) |
+| `baseOpacity` | number | 0.7 | Starting opacity for the first layer |
+| `opacityReduction` | number | 0.12 | Opacity reduction per layer |
+
+## Shape Categories
+
+Shapes are selected with layer-aware weighting — early layers favor simple shapes for background texture, later layers favor intricate ones for foreground detail.
+
+**Basic** — circle, square, triangle, hexagon, star, diamond, cube, heart
+
+**Complex** — platonic solids, fibonacci spiral, islamic pattern, celtic knot, merkaba, mandala, fractal
+
+**Sacred Geometry** — flower of life, tree of life, Metatron's cube, Sri Yantra, seed of life, vesica piscis, torus, egg of life
 
 ## Preset Sizes
 
-The package includes several preset configurations for common use cases:
-
 ```javascript
-import { PRESETS } from 'git-hash-art-generator';
+import { PRESETS } from 'git-hash-art';
 
-// Generate an Instagram-sized image
-generateImageFromHash(gitHash, PRESETS['instagram'].config);
-
-// Generate a mobile wallpaper
-generateImageFromHash(gitHash, PRESETS['phone-wallpaper'].config);
+// Use a preset's hash and config
+const preset = PRESETS['instagram-square'];
+const imageBuffer = generateImageFromHash(preset.hash, preset);
 ```
 
-Available presets include:
-- Standard (1024x1024)
-- Banner (1920x480)
-- Ultrawide (3440x1440)
-- Instagram (1080x1080)
-- Instagram Story (1080x1920)
-- Twitter Header (1500x500)
-- LinkedIn Banner (1584x396)
-- Phone Wallpaper (1170x2532)
-- Tablet Wallpaper (2048x2732)
-- Print sizes (A4/A3 at 300 DPI)
+Available presets:
+- Standard (1024×1024)
+- Banner (1920×480)
+- Ultrawide (3440×1440)
+- Instagram Square (1080×1080)
+- Instagram Story (1080×1920)
+- Twitter Header (1500×500)
+- LinkedIn Banner (1584×396)
+- Phone Wallpaper (1170×2532)
+- Tablet Wallpaper (2048×2732)
+- Minimal, Complex (special configurations)
 
 ## CLI Usage
 
-The package includes a command-line interface:
-
 ```bash
-# Generate with default settings
+# Generate from the current commit
 npx git-hash-art current
 
-# Generate from specific hash
+# Generate from a specific hash
 npx git-hash-art generate <hash>
 
-# Generate with custom size
+# Custom size
 npx git-hash-art generate <hash> --width 1920 --height 1080
 ```
 
@@ -115,7 +126,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
-      - run: npm install git-hash-art-generator
+      - run: npm install git-hash-art
       - run: npx git-hash-art current --output artwork/
 ```
 
@@ -124,7 +135,6 @@ jobs:
 ```bash
 #!/bin/sh
 # .git/hooks/post-commit
-
 hash=$(git rev-parse HEAD)
 npx git-hash-art generate $hash --output .git/artwork/
 ```


### PR DESCRIPTION
The README was out of date after the recent algorithm overhaul and visual effects PRs. This brings it in line with the current codebase.

## What changed

- Fixed stale default config values in the options table (width 1024→2048, layers 5→4, gridSize 4→5, etc.)
- Documented all new visual features: focal point composition, glow/shadow effects, gradient fills, watercolor transparency, color jitter, weighted shape selection
- Added a Shape Categories section explaining the three tiers (basic, complex, sacred) and layer-aware weighting
- Fixed the preset import path (`git-hash-art-generator` → `git-hash-art`)
- Added `saveImageToFile` to the basic usage example
- Fixed the GitHub Actions example to use the correct package name
- Updated the features list to accurately describe the current generation pipeline