### PR TITLE
feat: add cross-platform browser support

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -1,0 +1,16 @@
+# Product: git-hash-art
+
+A cross-platform library that generates deterministic abstract art from git commit hashes. Given a hex hash string, it produces a unique image using layered geometric shapes, sacred geometry patterns, and harmonious color schemes. Works in both Node.js and browser environments.
+
+Key capabilities:
+- Deterministic output: same hash always produces the same image
+- Configurable canvas size, grid density, layers, shape sizes, and opacity
+- Built-in presets for social media (Instagram, Twitter, LinkedIn), device wallpapers, and print sizes
+- CLI for generating art from the current commit or a specific hash
+- Cross-platform: Node.js (via `@napi-rs/canvas`) and browsers (native Canvas 2D API)
+
+## Public API
+
+- Node entry (`git-hash-art`): `generateImageFromHash` (returns PNG Buffer), `saveImageToFile`, `renderHashArt`
+- Browser entry (`git-hash-art/browser`): `renderToCanvas`, `generateImageBlob`, `generateDataURL`, `renderHashArt`
+- Both re-export `PRESETS`, `DEFAULT_CONFIG`, and the `GenerationConfig` type

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -1,0 +1,40 @@
+# Project Structure
+
+```
+src/
+  index.ts              # Node.js entry: generateImageFromHash, saveImageToFile, re-exports renderHashArt
+  browser.ts            # Browser entry: renderToCanvas, generateImageBlob, generateDataURL, re-exports renderHashArt
+  types.ts              # Shared GenerationConfig interface and DEFAULT_CONFIG
+  __tests__/            # Vitest test files (*.test.ts)
+  lib/
+    render.ts           # Pure rendering logic (environment-agnostic) — renderHashArt()
+    utils.ts            # Hash-to-seed conversion, deterministic RNG, PatternCombiner
+    constants.ts        # PRESETS, default shape config, proportions, pattern presets
+    canvas/
+      colors.ts         # Color scheme generation (generateColorScheme, SacredColorScheme class)
+      draw.ts           # Shape drawing and enhancement (drawShape, enhanceShapeGeneration)
+      shapes/
+        index.ts        # Aggregates and re-exports all shape draw functions
+        basic.ts        # Circle, square, triangle, hexagon, star
+        complex.ts      # Platonic solids, fibonacci, golden ratio shapes
+        sacred.ts       # Flower of life, tree of life, Metatron's cube, Sri Yantra
+        utils.ts        # Geometry helpers (transforms, degree conversion)
+bin/
+  generateExamples.js   # Script to generate example images from PRESETS
+examples/               # Generated example PNGs (gitignored)
+```
+
+## Architecture
+
+- `src/lib/render.ts` contains the pure rendering core (`renderHashArt`) that only uses the standard `CanvasRenderingContext2D` API — no Node or browser dependencies
+- `src/index.ts` is the Node entry point — wraps `renderHashArt` with `@napi-rs/canvas` for PNG buffer output and `fs` for file saving
+- `src/browser.ts` is the browser entry point — wraps `renderHashArt` with `HTMLCanvasElement`/`OffscreenCanvas` helpers
+- `@napi-rs/canvas` is an optional peer dependency, only required for Node.js usage
+
+## Conventions
+
+- Shape draw functions follow the `DrawFunction` signature: `(ctx: CanvasRenderingContext2D, size: number, config?: any) => void`
+- Shapes are grouped by category (basic, complex, sacred) and merged via the barrel `shapes/index.ts`
+- All randomness is derived deterministically from the git hash via `getRandomFromHash` — never use `Math.random()`
+- Tests live in `src/__tests__/` and use Vitest (`describe`/`it`/`expect`)
+- The `examples/` directory is gitignored; regenerate with `yarn build:examples`

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -1,0 +1,24 @@
+# Tech Stack
+
+- Language: TypeScript (strict mode, ES2020 target)
+- Runtime: Node.js and browsers
+- Canvas (Node): `@napi-rs/canvas` (optional peer dependency)
+- Canvas (Browser): native Canvas 2D API / OffscreenCanvas
+- Color generation: `color-scheme` (declared in `global.d.ts` since it lacks types)
+- Bundler: Parcel (outputs CJS `dist/main.js`, ESM `dist/module.js`, browser `dist/browser.js`, types `dist/types.d.ts`)
+- Test framework: Vitest
+- Formatter: Prettier
+- Release: release-it
+- Package manager: Yarn
+
+## Common Commands
+
+| Command | Purpose |
+|---|---|
+| `yarn build` | Production build (clears `.parcel-cache` first via `prebuild`) |
+| `yarn watch` | Dev build with file watching |
+| `npx vitest --run` | Run tests once |
+| `yarn format` | Format source files with Prettier |
+| `yarn format:check` | Check formatting without writing |
+| `yarn build:examples` | Generate example images via `bin/generateExamples.js` |
+| `yarn test:publish` | Dry-run npm publish |

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 Generate beautiful, deterministic abstract art from git commit hashes. Perfect for creating unique visual representations of your project's commits, generating placeholder images, or creating artistic wallpapers.
 
+Works in both Node.js and browser environments.
+
 ## Features
 
 - Deterministic output — same hash always produces the same image
 - Hash-derived harmonious color schemes (analogic, complementary, and triadic palettes)
 - 20+ shape types across three categories: basic, complex, and sacred geometry
 - Layered composition with depth — early layers use simple shapes, later layers use intricate ones
-- Focal point composition — hash-derived attractors create intentional-looking layouts
 - Watercolor-style transparency with semi-transparent fills and color blending
 - Glow effects on sacred geometry shapes for an ethereal quality
 - Radial gradient fills and organic color jitter for a hand-painted feel
@@ -16,6 +17,7 @@ Generate beautiful, deterministic abstract art from git commit hashes. Perfect f
 - Configurable canvas size, layers, shape sizes, and opacity
 - Built-in presets for social media, device wallpapers, and print sizes
 - CLI for generating art from the current commit or a specific hash
+- Cross-platform: runs in Node.js (via `@napi-rs/canvas`) and browsers (native Canvas API)
 
 ## Installation
 
@@ -23,7 +25,15 @@ Generate beautiful, deterministic abstract art from git commit hashes. Perfect f
 npm install git-hash-art
 ```
 
-## Basic Usage
+For Node.js usage you also need the canvas backend:
+
+```bash
+npm install @napi-rs/canvas
+```
+
+Browser usage requires no additional dependencies — the library uses the native Canvas 2D API.
+
+## Node.js Usage
 
 ```javascript
 import { generateImageFromHash, saveImageToFile } from 'git-hash-art';
@@ -36,9 +46,11 @@ const imageBuffer = generateImageFromHash(gitHash);
 saveImageToFile(imageBuffer, './output', gitHash, 'my-art', 2048, 2048);
 ```
 
-## Advanced Usage
+### Advanced Node.js Usage
 
 ```javascript
+import { generateImageFromHash } from 'git-hash-art';
+
 const config = {
   width: 1920,
   height: 1080,
@@ -54,19 +66,85 @@ const config = {
 const imageBuffer = generateImageFromHash(gitHash, config);
 ```
 
+## Browser Usage
+
+```javascript
+import { renderToCanvas, generateDataURL, generateImageBlob } from 'git-hash-art/browser';
+```
+
+### Render onto an existing canvas element
+
+```javascript
+import { renderToCanvas } from 'git-hash-art/browser';
+
+const canvas = document.getElementById('art-canvas');
+canvas.width = 1024;
+canvas.height = 1024;
+
+renderToCanvas(canvas, '46192e59d42f741c761cbea79462a8b3815dd905');
+```
+
+### Generate a data URL (for `<img>` tags)
+
+```javascript
+import { generateDataURL } from 'git-hash-art/browser';
+
+const dataUrl = generateDataURL('46192e59d42f741c761cbea79462a8b3815dd905', {
+  width: 512,
+  height: 512,
+});
+
+document.getElementById('preview').src = dataUrl;
+```
+
+### Generate a Blob (for downloads or uploads)
+
+```javascript
+import { generateImageBlob } from 'git-hash-art/browser';
+
+const blob = await generateImageBlob('46192e59d42f741c761cbea79462a8b3815dd905', {
+  width: 1080,
+  height: 1080,
+});
+
+// Trigger a download
+const url = URL.createObjectURL(blob);
+const a = document.createElement('a');
+a.href = url;
+a.download = 'hash-art.png';
+a.click();
+```
+
+## Core Renderer (Environment-Agnostic)
+
+If you need full control, both entry points re-export `renderHashArt` which
+accepts any standard `CanvasRenderingContext2D` — useful for custom canvas
+setups, Web Workers with `OffscreenCanvas`, or server-side rendering
+frameworks.
+
+```javascript
+import { renderHashArt } from 'git-hash-art'; // or 'git-hash-art/browser'
+
+const ctx = myCanvas.getContext('2d');
+renderHashArt(ctx, '46192e59d42f741c761cbea79462a8b3815dd905', {
+  width: myCanvas.width,
+  height: myCanvas.height,
+});
+```
+
 ## Configuration Options
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `width` | number | 2048 | Canvas width in pixels |
-| `height` | number | 2048 | Canvas height in pixels |
-| `gridSize` | number | 5 | Controls base shape count per layer (gridSize² × 1.5) |
-| `layers` | number | 4 | Number of layers to generate |
-| `shapesPerLayer` | number | auto | Base shapes per layer (defaults to gridSize² × 1.5) |
-| `minShapeSize` | number | 30 | Minimum shape size in pixels (scaled to canvas) |
-| `maxShapeSize` | number | 400 | Maximum shape size in pixels (scaled to canvas) |
-| `baseOpacity` | number | 0.7 | Starting opacity for the first layer |
-| `opacityReduction` | number | 0.12 | Opacity reduction per layer |
+| Option            | Type   | Default | Description                                          |
+| ----------------- | ------ | ------- | ---------------------------------------------------- |
+| `width`           | number | 2048    | Canvas width in pixels                               |
+| `height`          | number | 2048    | Canvas height in pixels                              |
+| `gridSize`        | number | 5       | Controls base shape count per layer (gridSize² × 1.5)|
+| `layers`          | number | 4       | Number of layers to generate                         |
+| `shapesPerLayer`  | number | auto    | Base shapes per layer (defaults to gridSize² × 1.5)  |
+| `minShapeSize`    | number | 30      | Minimum shape size in pixels (scaled to canvas)      |
+| `maxShapeSize`    | number | 400     | Maximum shape size in pixels (scaled to canvas)      |
+| `baseOpacity`     | number | 0.7     | Starting opacity for the first layer                 |
+| `opacityReduction`| number | 0.12    | Opacity reduction per layer                          |
 
 ## Shape Categories
 
@@ -89,6 +167,7 @@ const imageBuffer = generateImageFromHash(preset.hash, preset);
 ```
 
 Available presets:
+
 - Standard (1024×1024)
 - Banner (1920×480)
 - Ultrawide (3440×1440)
@@ -126,7 +205,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
-      - run: npm install git-hash-art
+      - run: npm install git-hash-art @napi-rs/canvas
       - run: npx git-hash-art current --output artwork/
 ```
 
@@ -137,6 +216,25 @@ jobs:
 # .git/hooks/post-commit
 hash=$(git rev-parse HEAD)
 npx git-hash-art generate $hash --output .git/artwork/
+```
+
+### React Component
+
+```jsx
+import { useEffect, useRef } from 'react';
+import { renderToCanvas } from 'git-hash-art/browser';
+
+function CommitArt({ hash, width = 256, height = 256 }) {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    if (canvasRef.current) {
+      renderToCanvas(canvasRef.current, hash, { width, height });
+    }
+  }, [hash, width, height]);
+
+  return <canvas ref={canvasRef} width={width} height={height} />;
+}
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@ Generate beautiful, deterministic abstract art from git commit hashes. Perfect f
 
 ## Features
 
-- Generate consistent, deterministic abstract art from any git hash
-- Configurable canvas sizes and output formats
-- Built-in presets for common social media and device sizes
-- Harmonious color schemes based on hash values
-- Grid-based composition system for balanced layouts
-- Multiple shape types and layering effects
-- Customizable output settings
+- Deterministic output — same hash always produces the same image
+- Hash-derived harmonious color schemes (analogic, complementary, and triadic palettes)
+- 20+ shape types across three categories: basic, complex, and sacred geometry
+- Layered composition with depth — early layers use simple shapes, later layers use intricate ones
+- Focal point composition — hash-derived attractors create intentional-looking layouts
+- Watercolor-style transparency with semi-transparent fills and color blending
+- Glow effects on sacred geometry shapes for an ethereal quality
+- Radial gradient fills and organic color jitter for a hand-painted feel
+- Organic bezier curves connecting nearby shapes
+- Configurable canvas size, layers, shape sizes, and opacity
+- Built-in presets for social media, device wallpapers, and print sizes
+- CLI for generating art from the current commit or a specific hash
 
 ## Installation
 
@@ -21,84 +26,90 @@ npm install git-hash-art
 ## Basic Usage
 
 ```javascript
-import { generateImageFromHash } from 'git-hash-art';
+import { generateImageFromHash, saveImageToFile } from 'git-hash-art';
 
-// Generate art from a git hash with default settings
+// Generate a PNG buffer from a git hash
 const gitHash = '46192e59d42f741c761cbea79462a8b3815dd905';
-generateImageFromHash(gitHash);
+const imageBuffer = generateImageFromHash(gitHash);
+
+// Save to disk
+saveImageToFile(imageBuffer, './output', gitHash, 'my-art', 2048, 2048);
 ```
 
 ## Advanced Usage
 
 ```javascript
-// Custom configuration
 const config = {
   width: 1920,
   height: 1080,
   gridSize: 6,
-  layers: 7,
-  shapesPerLayer: 30,
+  layers: 5,
+  shapesPerLayer: 40,
   minShapeSize: 20,
-  maxShapeSize: 180,
-  baseOpacity: 0.6,
-  opacityReduction: 0.1
+  maxShapeSize: 300,
+  baseOpacity: 0.7,
+  opacityReduction: 0.12
 };
 
-generateImageFromHash(gitHash, config);
+const imageBuffer = generateImageFromHash(gitHash, config);
 ```
 
 ## Configuration Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `width` | number | 1024 | Canvas width in pixels |
-| `height` | number | 1024 | Canvas height in pixels |
-| `gridSize` | number | 4 | Number of grid cells (gridSize x gridSize) |
-| `layers` | number | 5 | Number of layers to generate |
-| `shapesPerLayer` | number | - | Base number of shapes per layer (defaults to grid cells * 1.5) |
-| `minShapeSize` | number | 20 | Minimum shape size |
-| `maxShapeSize` | number | 180 | Maximum shape size |
-| `baseOpacity` | number | 0.6 | Starting opacity for first layer |
-| `opacityReduction` | number | 0.1 | How much to reduce opacity per layer |
+| `width` | number | 2048 | Canvas width in pixels |
+| `height` | number | 2048 | Canvas height in pixels |
+| `gridSize` | number | 5 | Controls base shape count per layer (gridSize² × 1.5) |
+| `layers` | number | 4 | Number of layers to generate |
+| `shapesPerLayer` | number | auto | Base shapes per layer (defaults to gridSize² × 1.5) |
+| `minShapeSize` | number | 30 | Minimum shape size in pixels (scaled to canvas) |
+| `maxShapeSize` | number | 400 | Maximum shape size in pixels (scaled to canvas) |
+| `baseOpacity` | number | 0.7 | Starting opacity for the first layer |
+| `opacityReduction` | number | 0.12 | Opacity reduction per layer |
+
+## Shape Categories
+
+Shapes are selected with layer-aware weighting — early layers favor simple shapes for background texture, later layers favor intricate ones for foreground detail.
+
+**Basic** — circle, square, triangle, hexagon, star, diamond, cube, heart
+
+**Complex** — platonic solids, fibonacci spiral, islamic pattern, celtic knot, merkaba, mandala, fractal
+
+**Sacred Geometry** — flower of life, tree of life, Metatron's cube, Sri Yantra, seed of life, vesica piscis, torus, egg of life
 
 ## Preset Sizes
 
-The package includes several preset configurations for common use cases:
-
 ```javascript
-import { PRESETS } from 'git-hash-art-generator';
+import { PRESETS } from 'git-hash-art';
 
-// Generate an Instagram-sized image
-generateImageFromHash(gitHash, PRESETS['instagram'].config);
-
-// Generate a mobile wallpaper
-generateImageFromHash(gitHash, PRESETS['phone-wallpaper'].config);
+// Use a preset's hash and config
+const preset = PRESETS['instagram-square'];
+const imageBuffer = generateImageFromHash(preset.hash, preset);
 ```
 
-Available presets include:
-- Standard (1024x1024)
-- Banner (1920x480)
-- Ultrawide (3440x1440)
-- Instagram (1080x1080)
-- Instagram Story (1080x1920)
-- Twitter Header (1500x500)
-- LinkedIn Banner (1584x396)
-- Phone Wallpaper (1170x2532)
-- Tablet Wallpaper (2048x2732)
-- Print sizes (A4/A3 at 300 DPI)
+Available presets:
+- Standard (1024×1024)
+- Banner (1920×480)
+- Ultrawide (3440×1440)
+- Instagram Square (1080×1080)
+- Instagram Story (1080×1920)
+- Twitter Header (1500×500)
+- LinkedIn Banner (1584×396)
+- Phone Wallpaper (1170×2532)
+- Tablet Wallpaper (2048×2732)
+- Minimal, Complex (special configurations)
 
 ## CLI Usage
 
-The package includes a command-line interface:
-
 ```bash
-# Generate with default settings
+# Generate from the current commit
 npx git-hash-art current
 
-# Generate from specific hash
+# Generate from a specific hash
 npx git-hash-art generate <hash>
 
-# Generate with custom size
+# Custom size
 npx git-hash-art generate <hash> --width 1920 --height 1080
 ```
 
@@ -115,7 +126,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
-      - run: npm install git-hash-art-generator
+      - run: npm install git-hash-art
       - run: npx git-hash-art current --output artwork/
 ```
 
@@ -124,7 +135,6 @@ jobs:
 ```bash
 #!/bin/sh
 # .git/hooks/post-commit
-
 hash=$(git rev-parse HEAD)
 npx git-hash-art generate $hash --output .git/artwork/
 ```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --write 'src/**/*.{ts,tsx,js,jsx,json,css,md}'",
     "format:check": "prettier --check 'src/**/*.{ts,tsx,js,jsx,json,css,md}'",
     "release": "release-it",
+    "test": "vitest --run",
     "test:publish": "npm publish --dry-run",
     "prepublishOnly": "yarn build"
   },
@@ -17,18 +18,61 @@
   "main": "dist/main.js",
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
+  "browser": "dist/browser.js",
+  "exports": {
+    ".": {
+      "node": {
+        "require": "./dist/main.js",
+        "import": "./dist/module.js",
+        "types": "./dist/types.d.ts"
+      },
+      "browser": {
+        "import": "./dist/browser.js",
+        "types": "./dist/browser-types.d.ts"
+      },
+      "default": "./dist/module.js"
+    },
+    "./browser": {
+      "import": "./dist/browser.js",
+      "types": "./dist/browser-types.d.ts"
+    }
+  },
+  "targets": {
+    "main": {
+      "context": "node",
+      "source": "src/index.ts"
+    },
+    "module": {
+      "context": "node",
+      "source": "src/index.ts"
+    },
+    "browser": {
+      "context": "browser",
+      "source": "src/browser.ts",
+      "outputFormat": "esmodule"
+    }
+  },
   "license": "MIT",
   "dependencies": {
-    "@napi-rs/canvas": "^0.1.97",
     "color-scheme": "^1.0.1"
   },
+  "peerDependencies": {
+    "@napi-rs/canvas": ">=0.1.97"
+  },
+  "peerDependenciesMeta": {
+    "@napi-rs/canvas": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@napi-rs/canvas": "^0.1.97",
     "@parcel/packager-ts": "^2.12.0",
     "@parcel/transformer-typescript-types": "^2.12.0",
     "@types/node": "^22.8.2",
     "parcel": "^2.12.0",
     "prettier": "^3.3.3",
     "release-it": "^17.10.0",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^2"
   }
 }

--- a/src/__tests__/compatibility.test.ts
+++ b/src/__tests__/compatibility.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { createCanvas } from "@napi-rs/canvas";
+
+const TEST_HASH = "46192e59d42f741c761cbea79462a8b3815dd905";
+
+describe("@napi-rs/canvas compatibility", () => {
+  it("createCanvas produces a valid canvas with 2d context", () => {
+    const canvas = createCanvas(256, 256);
+    const ctx = canvas.getContext("2d");
+    expect(ctx).toBeDefined();
+    expect(typeof ctx.fillRect).toBe("function");
+    expect(typeof ctx.beginPath).toBe("function");
+    expect(typeof ctx.arc).toBe("function");
+  });
+
+  it("canvas.toBuffer produces a valid PNG buffer", () => {
+    const canvas = createCanvas(64, 64);
+    const ctx = canvas.getContext("2d");
+    ctx.fillStyle = "#ff0000";
+    ctx.fillRect(0, 0, 64, 64);
+    const buf = canvas.toBuffer("image/png");
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf.length).toBeGreaterThan(0);
+    // PNG magic bytes
+    expect(buf[0]).toBe(0x89);
+    expect(buf[1]).toBe(0x50); // P
+    expect(buf[2]).toBe(0x4e); // N
+    expect(buf[3]).toBe(0x47); // G
+  });
+
+  it("gradient API works", () => {
+    const canvas = createCanvas(128, 128);
+    const ctx = canvas.getContext("2d");
+    const gradient = ctx.createLinearGradient(0, 0, 128, 128);
+    gradient.addColorStop(0, "#000000");
+    gradient.addColorStop(1, "#ffffff");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, 128, 128);
+    const buf = canvas.toBuffer("image/png");
+    expect(buf.length).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/generation.test.ts
+++ b/src/__tests__/generation.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { generateImageFromHash } from "../index";
+
+const TEST_HASH = "46192e59d42f741c761cbea79462a8b3815dd905";
+
+describe("generateImageFromHash", () => {
+  it("produces a valid PNG buffer with default config", () => {
+    const buf = generateImageFromHash(TEST_HASH, { width: 128, height: 128 });
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    expect(buf[0]).toBe(0x89);
+    expect(buf[1]).toBe(0x50);
+    expect(buf[2]).toBe(0x4e);
+    expect(buf[3]).toBe(0x47);
+  });
+
+  it("is deterministic — same hash produces identical output", () => {
+    const config = { width: 128, height: 128, gridSize: 4 };
+    const buf1 = generateImageFromHash(TEST_HASH, config);
+    const buf2 = generateImageFromHash(TEST_HASH, config);
+    expect(buf1.equals(buf2)).toBe(true);
+  });
+
+  it("different hashes produce different images", () => {
+    const config = { width: 128, height: 128, gridSize: 4 };
+    const buf1 = generateImageFromHash(TEST_HASH, config);
+    const buf2 = generateImageFromHash(
+      "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      config,
+    );
+    expect(buf1.equals(buf2)).toBe(false);
+  });
+
+  it("respects custom dimensions", () => {
+    const buf = generateImageFromHash(TEST_HASH, { width: 64, height: 32 });
+    expect(buf.length).toBeGreaterThan(0);
+  });
+
+  it("handles non-square aspect ratios", () => {
+    expect(() =>
+      generateImageFromHash(TEST_HASH, {
+        width: 1920,
+        height: 480,
+        gridSize: 8,
+      }),
+    ).not.toThrow();
+  });
+
+  it("handles high layer count without crashing", () => {
+    expect(() =>
+      generateImageFromHash(TEST_HASH, {
+        width: 128,
+        height: 128,
+        layers: 5,
+        gridSize: 4,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/__tests__/render.test.ts
+++ b/src/__tests__/render.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { createCanvas } from "@napi-rs/canvas";
+import { renderHashArt } from "../lib/render";
+
+const TEST_HASH = "46192e59d42f741c761cbea79462a8b3815dd905";
+
+function createTestCtx(width = 128, height = 128) {
+  const canvas = createCanvas(width, height);
+  return canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
+}
+
+describe("renderHashArt (core renderer)", () => {
+  it("renders without error on a provided context", () => {
+    const ctx = createTestCtx();
+    expect(() =>
+      renderHashArt(ctx, TEST_HASH, { width: 128, height: 128 }),
+    ).not.toThrow();
+  });
+
+  it("is deterministic — same hash + config produces identical pixel data", () => {
+    const canvas1 = createCanvas(64, 64);
+    const canvas2 = createCanvas(64, 64);
+    const config = { width: 64, height: 64, gridSize: 3 };
+
+    renderHashArt(
+      canvas1.getContext("2d") as unknown as CanvasRenderingContext2D,
+      TEST_HASH,
+      config,
+    );
+    renderHashArt(
+      canvas2.getContext("2d") as unknown as CanvasRenderingContext2D,
+      TEST_HASH,
+      config,
+    );
+
+    const buf1 = canvas1.toBuffer("image/png");
+    const buf2 = canvas2.toBuffer("image/png");
+    expect(buf1.equals(buf2)).toBe(true);
+  });
+
+  it("different hashes produce different output", () => {
+    const canvas1 = createCanvas(64, 64);
+    const canvas2 = createCanvas(64, 64);
+    const config = { width: 64, height: 64, gridSize: 3 };
+
+    renderHashArt(
+      canvas1.getContext("2d") as unknown as CanvasRenderingContext2D,
+      TEST_HASH,
+      config,
+    );
+    renderHashArt(
+      canvas2.getContext("2d") as unknown as CanvasRenderingContext2D,
+      "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      config,
+    );
+
+    const buf1 = canvas1.toBuffer("image/png");
+    const buf2 = canvas2.toBuffer("image/png");
+    expect(buf1.equals(buf2)).toBe(false);
+  });
+
+  it("uses defaults when no config is provided", () => {
+    // Large default canvas — just verify it doesn't throw
+    const canvas = createCanvas(2048, 2048);
+    const ctx = canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
+    expect(() => renderHashArt(ctx, TEST_HASH)).not.toThrow();
+  });
+
+  it("respects custom config values", () => {
+    const ctx = createTestCtx(256, 128);
+    expect(() =>
+      renderHashArt(ctx, TEST_HASH, {
+        width: 256,
+        height: 128,
+        layers: 2,
+        gridSize: 3,
+        baseOpacity: 0.5,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/__tests__/shapes.test.ts
+++ b/src/__tests__/shapes.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { createCanvas } from "@napi-rs/canvas";
+import { shapes } from "../lib/canvas/shapes";
+import { drawShape, enhanceShapeGeneration } from "../lib/canvas/draw";
+
+const TEST_HASH = "46192e59d42f741c761cbea79462a8b3815dd905";
+
+function createTestCtx(size = 256) {
+  const canvas = createCanvas(size, size);
+  return canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
+}
+
+describe("all shapes render without crashing", () => {
+  const shapeNames = Object.keys(shapes);
+
+  it.each(shapeNames)("shape '%s' draws without error", (name) => {
+    const ctx = createTestCtx();
+    expect(() => shapes[name](ctx, 100)).not.toThrow();
+  });
+
+  it.each(shapeNames)("shape '%s' works through drawShape()", (name) => {
+    const ctx = createTestCtx();
+    expect(() =>
+      drawShape(ctx, name, 128, 128, {
+        fillColor: "#ff0000",
+        strokeColor: "#000000",
+        strokeWidth: 2,
+        size: 80,
+        rotation: 45,
+      }),
+    ).not.toThrow();
+  });
+
+  it.each(shapeNames)(
+    "shape '%s' works through enhanceShapeGeneration()",
+    (name) => {
+      const ctx = createTestCtx();
+      expect(() =>
+        enhanceShapeGeneration(ctx, name, 128, 128, {
+          fillColor: "#ff0000",
+          strokeColor: "#000000",
+          strokeWidth: 2,
+          size: 80,
+          rotation: 45,
+          proportionType: "GOLDEN_RATIO",
+        }),
+      ).not.toThrow();
+    },
+  );
+});
+
+describe("platonicSolid handles missing config.type gracefully", () => {
+  it("renders with no config at all", () => {
+    const ctx = createTestCtx();
+    expect(() => shapes["platonicSolid"](ctx, 100)).not.toThrow();
+  });
+
+  it("renders with explicit type", () => {
+    const ctx = createTestCtx();
+    expect(() =>
+      shapes["platonicSolid"](ctx, 100, { type: "tetrahedron" }),
+    ).not.toThrow();
+  });
+
+  it("renders with invalid type (falls back)", () => {
+    const ctx = createTestCtx();
+    expect(() =>
+      shapes["platonicSolid"](ctx, 100, { type: "nonexistent" }),
+    ).not.toThrow();
+  });
+});

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,105 @@
+/**
+ * Browser entry point for git-hash-art.
+ *
+ * This module has zero Node.js dependencies — it works with a standard
+ * HTMLCanvasElement or OffscreenCanvas and the native Canvas 2D API.
+ */
+import { renderHashArt } from "./lib/render";
+import type { GenerationConfig } from "./types";
+import { DEFAULT_CONFIG } from "./types";
+
+/**
+ * Render hash-derived art directly onto an HTMLCanvasElement.
+ *
+ * The canvas should already have the desired width/height set.
+ * Config width/height will be inferred from the canvas if not provided.
+ *
+ * @param canvas  - An HTMLCanvasElement (or OffscreenCanvas)
+ * @param gitHash - Hex hash string used as the deterministic seed
+ * @param config  - Partial generation config (merged with defaults)
+ */
+function renderToCanvas(
+  canvas: HTMLCanvasElement | OffscreenCanvas,
+  gitHash: string,
+  config: Partial<GenerationConfig> = {},
+): void {
+  const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
+  if (!ctx) {
+    throw new Error("Failed to get 2D rendering context from canvas");
+  }
+
+  const finalConfig: Partial<GenerationConfig> = {
+    width: canvas.width,
+    height: canvas.height,
+    ...config,
+  };
+
+  renderHashArt(ctx, gitHash, finalConfig);
+}
+
+/**
+ * Render hash-derived art and return it as a Blob (browser-native).
+ *
+ * @param gitHash - Hex hash string used as the deterministic seed
+ * @param config  - Partial generation config (merged with defaults)
+ * @returns A Promise that resolves to a PNG Blob
+ */
+async function generateImageBlob(
+  gitHash: string,
+  config: Partial<GenerationConfig> = {},
+): Promise<Blob> {
+  const finalConfig: GenerationConfig = { ...DEFAULT_CONFIG, ...config };
+  const { width, height } = finalConfig;
+
+  const canvas = new OffscreenCanvas(width, height);
+  const ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
+  if (!ctx) {
+    throw new Error("Failed to get 2D rendering context from OffscreenCanvas");
+  }
+
+  renderHashArt(
+    ctx as unknown as CanvasRenderingContext2D,
+    gitHash,
+    finalConfig,
+  );
+
+  return canvas.convertToBlob({ type: "image/png" });
+}
+
+/**
+ * Render hash-derived art and return it as a data URL string.
+ *
+ * @param gitHash - Hex hash string used as the deterministic seed
+ * @param config  - Partial generation config (merged with defaults)
+ * @returns A data:image/png;base64,… string
+ */
+function generateDataURL(
+  gitHash: string,
+  config: Partial<GenerationConfig> = {},
+): string {
+  const finalConfig: GenerationConfig = { ...DEFAULT_CONFIG, ...config };
+  const { width, height } = finalConfig;
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Failed to get 2D rendering context");
+  }
+
+  renderHashArt(ctx, gitHash, finalConfig);
+
+  return canvas.toDataURL("image/png");
+}
+
+export {
+  renderToCanvas,
+  generateImageBlob,
+  generateDataURL,
+  renderHashArt,
+};
+export { PRESETS } from "./lib/constants";
+export type { GenerationConfig } from "./types";
+export { DEFAULT_CONFIG } from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,290 +1,54 @@
 import { createCanvas } from "@napi-rs/canvas";
-import {
-  SacredColorScheme,
-  hexWithAlpha,
-  jitterColor,
-} from "./lib/canvas/colors";
-import { enhanceShapeGeneration } from "./lib/canvas/draw";
-import { shapes } from "./lib/canvas/shapes";
-import { createRng, seedFromHash } from "./lib/utils";
-
-// Shape categories for weighted selection per layer
-const BASIC_SHAPES = [
-  "circle",
-  "square",
-  "triangle",
-  "hexagon",
-  "diamond",
-  "cube",
-];
-const COMPLEX_SHAPES = [
-  "star",
-  "jacked-star",
-  "heart",
-  "platonicSolid",
-  "fibonacciSpiral",
-  "islamicPattern",
-  "celticKnot",
-  "merkaba",
-  "fractal",
-];
-const SACRED_SHAPES = [
-  "mandala",
-  "flowerOfLife",
-  "treeOfLife",
-  "metatronsCube",
-  "sriYantra",
-  "seedOfLife",
-  "vesicaPiscis",
-  "torus",
-  "eggOfLife",
-];
+import * as fs from "fs";
+import * as path from "path";
+import { renderHashArt } from "./lib/render";
+import type { GenerationConfig } from "./types";
+import { DEFAULT_CONFIG } from "./types";
 
 /**
- * Pick a shape name using layer-weighted selection.
- * Early layers favor basic shapes; later layers favor complex/sacred.
+ * Generate an abstract art PNG buffer from a git hash (Node.js only).
+ *
+ * Uses @napi-rs/canvas under the hood to create an off-screen canvas,
+ * renders the hash-derived art, and returns the result as a PNG Buffer.
+ *
+ * @param gitHash - Hex hash string used as the deterministic seed
+ * @param config  - Partial generation config (merged with defaults)
+ * @returns PNG buffer of the generated image
  */
-function pickShape(
-  rng: () => number,
-  layerRatio: number,
-  shapeNames: string[],
-): string {
-  // layerRatio: 0 = first layer, 1 = last layer
-  const basicWeight = 1 - layerRatio * 0.6;
-  const complexWeight = 0.3 + layerRatio * 0.3;
-  const sacredWeight = 0.1 + layerRatio * 0.4;
-  const total = basicWeight + complexWeight + sacredWeight;
-
-  const roll = rng() * total;
-  let pool: string[];
-  if (roll < basicWeight) {
-    pool = BASIC_SHAPES;
-  } else if (roll < basicWeight + complexWeight) {
-    pool = COMPLEX_SHAPES;
-  } else {
-    pool = SACRED_SHAPES;
-  }
-
-  // Filter to shapes that actually exist in the registry
-  const available = pool.filter((s) => shapeNames.includes(s));
-  if (available.length === 0) {
-    return shapeNames[Math.floor(rng() * shapeNames.length)];
-  }
-  return available[Math.floor(rng() * available.length)];
-}
-
-/**
- * Generate an abstract art image from a git hash with custom configuration
- * @param {string} gitHash - The git hash to use as a seed
- * @param {object} [config={}] - Configuration options
- * @returns {Buffer} PNG buffer of the generated image
- */
-function generateImageFromHash(gitHash: string, config = {}) {
-  const defaultConfig = {
-    width: 2048,
-    height: 2048,
-    gridSize: 5,
-    layers: 4,
-    minShapeSize: 30,
-    maxShapeSize: 400,
-    baseOpacity: 0.7,
-    opacityReduction: 0.12,
-    shapesPerLayer: 0,
-  };
-
-  const finalConfig = { ...defaultConfig, ...config };
-  const {
-    width,
-    height,
-    gridSize,
-    layers,
-    minShapeSize,
-    maxShapeSize,
-    baseOpacity,
-    opacityReduction,
-  } = finalConfig;
-
-  finalConfig.shapesPerLayer =
-    finalConfig.shapesPerLayer || Math.floor(gridSize * gridSize * 1.5);
+function generateImageFromHash(
+  gitHash: string,
+  config: Partial<GenerationConfig> = {},
+): Buffer {
+  const finalConfig: GenerationConfig = { ...DEFAULT_CONFIG, ...config };
+  const { width, height } = finalConfig;
 
   const canvas = createCanvas(width, height);
   const ctx = canvas.getContext("2d") as unknown as CanvasRenderingContext2D;
 
-  // --- Color scheme derived from hash ---
-  const colorScheme = new SacredColorScheme(gitHash);
-  const colors = colorScheme.getColors();
-  const [bgStart, bgEnd] = colorScheme.getBackgroundColors();
+  renderHashArt(ctx, gitHash, finalConfig);
 
-  // --- Radial gradient background for depth ---
-  const cx = width / 2;
-  const cy = height / 2;
-  const bgRadius = Math.hypot(cx, cy);
-  const gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, bgRadius);
-  gradient.addColorStop(0, bgStart);
-  gradient.addColorStop(1, bgEnd);
-  ctx.fillStyle = gradient;
-  ctx.fillRect(0, 0, width, height);
-
-  const shapeNames = Object.keys(shapes);
-  const scaleFactor = Math.min(width, height) / 1024;
-  const adjustedMinSize = minShapeSize * scaleFactor;
-  const adjustedMaxSize = maxShapeSize * scaleFactor;
-
-  // One master RNG seeded from the full hash
-  const rng = createRng(seedFromHash(gitHash));
-
-  // --- Focal points: 1-3 hash-derived attractors that bias shape placement ---
-  const numFocal = 1 + Math.floor(rng() * 2); // 1-2 focal points
-  const focalPoints: Array<{ x: number; y: number; strength: number }> = [];
-  for (let f = 0; f < numFocal; f++) {
-    focalPoints.push({
-      x: width * (0.2 + rng() * 0.6), // keep away from edges
-      y: height * (0.2 + rng() * 0.6),
-      strength: 0.3 + rng() * 0.4,
-    });
-  }
-
-  /**
-   * Bias a position toward the nearest focal point.
-   * Returns a blended position between the random point and the focal point.
-   */
-  function applyFocalBias(rx: number, ry: number): [number, number] {
-    // Find nearest focal point
-    let nearest = focalPoints[0];
-    let minDist = Infinity;
-    for (const fp of focalPoints) {
-      const d = Math.hypot(rx - fp.x, ry - fp.y);
-      if (d < minDist) {
-        minDist = d;
-        nearest = fp;
-      }
-    }
-    // Blend toward focal point based on strength and a random factor
-    const pull = nearest.strength * rng() * 0.5;
-    return [rx + (nearest.x - rx) * pull, ry + (nearest.y - ry) * pull];
-  }
-
-  const shapePositions: Array<{ x: number; y: number }> = [];
-
-  for (let layer = 0; layer < layers; layer++) {
-    const layerRatio = layers > 1 ? layer / (layers - 1) : 0;
-    const numShapes =
-      finalConfig.shapesPerLayer +
-      Math.floor(rng() * finalConfig.shapesPerLayer * 0.3);
-
-    const layerOpacity = Math.max(0.15, baseOpacity - layer * opacityReduction);
-    const layerSizeScale = 1 - layer * 0.15;
-
-    for (let i = 0; i < numShapes; i++) {
-      // Random position biased toward focal points
-      const rawX = rng() * width;
-      const rawY = rng() * height;
-      const [x, y] = applyFocalBias(rawX, rawY);
-
-      // Weighted shape selection: basic early, complex/sacred later
-      const shape = pickShape(rng, layerRatio, shapeNames);
-
-      const sizeT = Math.pow(rng(), 1.8);
-      const size =
-        (adjustedMinSize + sizeT * (adjustedMaxSize - adjustedMinSize)) *
-        layerSizeScale;
-
-      const rotation = rng() * 360;
-
-      // Color jitter: slight variation on each pick for organic feel
-      const baseFill = colors[Math.floor(rng() * colors.length)];
-      const baseStroke = colors[Math.floor(rng() * colors.length)];
-      const fillColor = jitterColor(baseFill, rng, 0.08);
-      const strokeColor = jitterColor(baseStroke, rng, 0.06);
-
-      // Semi-transparent fill for watercolor layering effect
-      const fillAlpha = 0.25 + rng() * 0.5;
-      const transparentFill = hexWithAlpha(fillColor, fillAlpha);
-
-      const strokeWidth = (0.5 + rng() * 2.0) * scaleFactor;
-
-      ctx.globalAlpha = layerOpacity * (0.5 + rng() * 0.5);
-
-      // Glow: ~25% of shapes get a soft glow, more likely on sacred shapes
-      const isSacred = SACRED_SHAPES.includes(shape);
-      const glowChance = isSacred ? 0.45 : 0.2;
-      const hasGlow = rng() < glowChance;
-      const glowRadius = hasGlow ? (8 + rng() * 20) * scaleFactor : 0;
-
-      // Gradient fill: ~30% of shapes get a radial gradient
-      const hasGradient = rng() < 0.3;
-      const gradientEnd = hasGradient
-        ? jitterColor(colors[Math.floor(rng() * colors.length)], rng, 0.1)
-        : undefined;
-
-      enhanceShapeGeneration(ctx, shape, x, y, {
-        fillColor: transparentFill,
-        strokeColor,
-        strokeWidth,
-        size,
-        rotation,
-        proportionType: "GOLDEN_RATIO",
-        glowRadius,
-        glowColor: hasGlow ? hexWithAlpha(fillColor, 0.6) : undefined,
-        gradientFillEnd: gradientEnd,
-      });
-
-      shapePositions.push({ x, y });
-    }
-  }
-
-  // --- Organic connecting curves between nearby shapes ---
-  if (shapePositions.length > 1) {
-    const numCurves = Math.floor((8 * (width * height)) / (1024 * 1024));
-    ctx.lineWidth = 0.8 * scaleFactor;
-
-    for (let i = 0; i < numCurves; i++) {
-      const idxA = Math.floor(rng() * shapePositions.length);
-      const offset =
-        1 + Math.floor(rng() * Math.min(5, shapePositions.length - 1));
-      const idxB = (idxA + offset) % shapePositions.length;
-
-      const a = shapePositions[idxA];
-      const b = shapePositions[idxB];
-
-      const mx = (a.x + b.x) / 2;
-      const my = (a.y + b.y) / 2;
-      const dx = b.x - a.x;
-      const dy = b.y - a.y;
-      const dist = Math.hypot(dx, dy);
-      const bulge = (rng() - 0.5) * dist * 0.4;
-
-      const cpx = mx + (-dy / (dist || 1)) * bulge;
-      const cpy = my + (dx / (dist || 1)) * bulge;
-
-      ctx.globalAlpha = 0.08 + rng() * 0.12;
-      ctx.strokeStyle = hexWithAlpha(
-        colors[Math.floor(rng() * colors.length)],
-        0.3,
-      );
-
-      ctx.beginPath();
-      ctx.moveTo(a.x, a.y);
-      ctx.quadraticCurveTo(cpx, cpy, b.x, b.y);
-      ctx.stroke();
-    }
-  }
-
-  ctx.globalAlpha = 1;
   return canvas.toBuffer("image/png");
 }
 
 /**
- * Save the generated image to a file
+ * Save the generated image to a file (Node.js only).
+ *
+ * @param imageBuffer - The PNG buffer of the generated image
+ * @param outputDir   - The directory to save the image
+ * @param gitHash     - The git hash used to generate the image
+ * @param label       - Optional label for the output filename
+ * @param width       - The width of the generated image
+ * @param height      - The height of the generated image
+ * @returns Path to the saved image
  */
 function saveImageToFile(
-  imageBuffer: string,
+  imageBuffer: Buffer,
   outputDir: string,
-  gitHash: string | any[],
+  gitHash: string,
   label = "",
-  width: any,
-  height: any,
-) {
+  width: number,
+  height: number,
+): string {
   if (!fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir, { recursive: true });
   }
@@ -300,4 +64,7 @@ function saveImageToFile(
   return outputPath;
 }
 
-export { generateImageFromHash, saveImageToFile };
+export { generateImageFromHash, saveImageToFile, renderHashArt };
+export { PRESETS } from "./lib/constants";
+export type { GenerationConfig } from "./types";
+export { DEFAULT_CONFIG } from "./types";

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -1,0 +1,152 @@
+/**
+ * Pure rendering logic — environment-agnostic.
+ *
+ * This module only uses the standard CanvasRenderingContext2D API,
+ * so it works identically in Node (@napi-rs/canvas) and browsers
+ * (HTMLCanvasElement).
+ */
+import { SacredColorScheme } from "./canvas/colors";
+import { enhanceShapeGeneration } from "./canvas/draw";
+import { shapes } from "./canvas/shapes";
+import { createRng, seedFromHash } from "./utils";
+import { DEFAULT_CONFIG, type GenerationConfig } from "../types";
+
+/**
+ * Render hash-derived art onto an existing CanvasRenderingContext2D.
+ *
+ * This is the environment-agnostic core — it never creates a canvas or
+ * produces a buffer. Call it from Node or browser wrappers that supply
+ * the context.
+ *
+ * @param ctx  - A 2D rendering context (browser or Node canvas)
+ * @param gitHash - Hex hash string used as the deterministic seed
+ * @param config  - Partial generation config (merged with defaults)
+ */
+export function renderHashArt(
+  ctx: CanvasRenderingContext2D,
+  gitHash: string,
+  config: Partial<GenerationConfig> = {},
+): void {
+  const finalConfig: GenerationConfig = { ...DEFAULT_CONFIG, ...config };
+  const {
+    width,
+    height,
+    gridSize,
+    layers,
+    minShapeSize,
+    maxShapeSize,
+    baseOpacity,
+    opacityReduction,
+  } = finalConfig;
+
+  finalConfig.shapesPerLayer =
+    finalConfig.shapesPerLayer || Math.floor(gridSize * gridSize * 1.5);
+
+  // --- Color scheme derived from hash ---
+  const colorScheme = new SacredColorScheme(gitHash);
+  const colors = colorScheme.getColors();
+  const [bgStart, bgEnd] = colorScheme.getBackgroundColors();
+
+  // --- Radial gradient background for depth ---
+  const cx = width / 2;
+  const cy = height / 2;
+  const bgRadius = Math.hypot(cx, cy);
+  const gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, bgRadius);
+  gradient.addColorStop(0, bgStart);
+  gradient.addColorStop(1, bgEnd);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+
+  const shapeNames = Object.keys(shapes);
+  const scaleFactor = Math.min(width, height) / 1024;
+  const adjustedMinSize = minShapeSize * scaleFactor;
+  const adjustedMaxSize = maxShapeSize * scaleFactor;
+
+  // One master RNG seeded from the full hash — all randomness flows from here
+  const rng = createRng(seedFromHash(gitHash));
+
+  // Track shape positions for organic connecting curves later
+  const shapePositions: Array<{ x: number; y: number }> = [];
+
+  for (let layer = 0; layer < layers; layer++) {
+    const numShapes =
+      finalConfig.shapesPerLayer +
+      Math.floor(rng() * finalConfig.shapesPerLayer * 0.3);
+
+    // Layer opacity decays gently so all layers remain visible
+    const layerOpacity = Math.max(0.15, baseOpacity - layer * opacityReduction);
+
+    // Later layers use smaller shapes for depth
+    const layerSizeScale = 1 - layer * 0.15;
+
+    for (let i = 0; i < numShapes; i++) {
+      const x = rng() * width;
+      const y = rng() * height;
+
+      const shapeIdx = Math.floor(rng() * shapeNames.length);
+      const shape = shapeNames[shapeIdx];
+
+      // Shape size follows a power distribution — many small, few large
+      const sizeT = Math.pow(rng(), 1.8);
+      const size =
+        (adjustedMinSize + sizeT * (adjustedMaxSize - adjustedMinSize)) *
+        layerSizeScale;
+
+      const rotation = rng() * 360;
+
+      const fillColor = colors[Math.floor(rng() * colors.length)];
+      const strokeColor = colors[Math.floor(rng() * colors.length)];
+
+      const strokeWidth = (0.5 + rng() * 2.0) * scaleFactor;
+
+      ctx.globalAlpha = layerOpacity * (0.5 + rng() * 0.5);
+
+      enhanceShapeGeneration(ctx, shape, x, y, {
+        fillColor,
+        strokeColor,
+        strokeWidth,
+        size,
+        rotation,
+        proportionType: "GOLDEN_RATIO",
+      });
+
+      shapePositions.push({ x, y });
+    }
+  }
+
+  // --- Organic connecting curves between nearby shapes ---
+  if (shapePositions.length > 1) {
+    const numCurves = Math.floor((8 * (width * height)) / (1024 * 1024));
+    ctx.lineWidth = 0.8 * scaleFactor;
+
+    for (let i = 0; i < numCurves; i++) {
+      const idxA = Math.floor(rng() * shapePositions.length);
+      const offset =
+        1 + Math.floor(rng() * Math.min(5, shapePositions.length - 1));
+      const idxB = (idxA + offset) % shapePositions.length;
+
+      const a = shapePositions[idxA];
+      const b = shapePositions[idxB];
+
+      const mx = (a.x + b.x) / 2;
+      const my = (a.y + b.y) / 2;
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const dist = Math.hypot(dx, dy);
+      const bulge = (rng() - 0.5) * dist * 0.4;
+
+      const cpx = mx + (-dy / (dist || 1)) * bulge;
+      const cpy = my + (dx / (dist || 1)) * bulge;
+
+      ctx.globalAlpha = 0.08 + rng() * 0.12;
+      ctx.strokeStyle = colors[Math.floor(rng() * colors.length)];
+
+      ctx.beginPath();
+      ctx.moveTo(a.x, a.y);
+      ctx.quadraticCurveTo(cpx, cpy, b.x, b.y);
+      ctx.stroke();
+    }
+  }
+
+  ctx.globalAlpha = 1;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Configuration options for image generation.
+ */
+export interface GenerationConfig {
+  /** Canvas width in pixels (default: 2048) */
+  width: number;
+  /** Canvas height in pixels (default: 2048) */
+  height: number;
+  /** Controls base shape count per layer — gridSize² × 1.5 (default: 5) */
+  gridSize: number;
+  /** Number of layers to generate (default: 4) */
+  layers: number;
+  /** Minimum shape size in pixels, scaled to canvas (default: 30) */
+  minShapeSize: number;
+  /** Maximum shape size in pixels, scaled to canvas (default: 400) */
+  maxShapeSize: number;
+  /** Starting opacity for the first layer (default: 0.7) */
+  baseOpacity: number;
+  /** Opacity reduction per layer (default: 0.12) */
+  opacityReduction: number;
+  /** Base shapes per layer — defaults to gridSize² × 1.5 when 0 */
+  shapesPerLayer: number;
+}
+
+export const DEFAULT_CONFIG: GenerationConfig = {
+  width: 2048,
+  height: 2048,
+  gridSize: 5,
+  layers: 4,
+  minShapeSize: 30,
+  maxShapeSize: 400,
+  baseOpacity: 0.7,
+  opacityReduction: 0.12,
+  shapesPerLayer: 0,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,121 @@
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz"
   integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
+"@esbuild/aix-ppc64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
+  integrity sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==
+
+"@esbuild/android-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz#09d9b4357780da9ea3a7dfb833a1f1ff439b4052"
+  integrity sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==
+
+"@esbuild/android-arm@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.21.5.tgz#9b04384fb771926dfa6d7ad04324ecb2ab9b2e28"
+  integrity sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==
+
+"@esbuild/android-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.21.5.tgz#29918ec2db754cedcb6c1b04de8cd6547af6461e"
+  integrity sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==
+
+"@esbuild/darwin-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz#e495b539660e51690f3928af50a76fb0a6ccff2a"
+  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+
+"@esbuild/darwin-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz#c13838fa57372839abdddc91d71542ceea2e1e22"
+  integrity sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
+
+"@esbuild/freebsd-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz#646b989aa20bf89fd071dd5dbfad69a3542e550e"
+  integrity sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==
+
+"@esbuild/freebsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz#aa615cfc80af954d3458906e38ca22c18cf5c261"
+  integrity sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==
+
+"@esbuild/linux-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz#70ac6fa14f5cb7e1f7f887bcffb680ad09922b5b"
+  integrity sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
+
+"@esbuild/linux-arm@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz#fc6fd11a8aca56c1f6f3894f2bea0479f8f626b9"
+  integrity sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==
+
+"@esbuild/linux-ia32@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz#3271f53b3f93e3d093d518d1649d6d68d346ede2"
+  integrity sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==
+
+"@esbuild/linux-loong64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz#ed62e04238c57026aea831c5a130b73c0f9f26df"
+  integrity sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==
+
+"@esbuild/linux-mips64el@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz#e79b8eb48bf3b106fadec1ac8240fb97b4e64cbe"
+  integrity sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==
+
+"@esbuild/linux-ppc64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz#5f2203860a143b9919d383ef7573521fb154c3e4"
+  integrity sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==
+
+"@esbuild/linux-riscv64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz#07bcafd99322d5af62f618cb9e6a9b7f4bb825dc"
+  integrity sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==
+
+"@esbuild/linux-s390x@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz#b7ccf686751d6a3e44b8627ababc8be3ef62d8de"
+  integrity sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==
+
+"@esbuild/linux-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz#6d8f0c768e070e64309af8004bb94e68ab2bb3b0"
+  integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
+
+"@esbuild/netbsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz#bbe430f60d378ecb88decb219c602667387a6047"
+  integrity sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==
+
+"@esbuild/openbsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz#99d1cf2937279560d2104821f5ccce220cb2af70"
+  integrity sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==
+
+"@esbuild/sunos-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz#08741512c10d529566baba837b4fe052c8f3487b"
+  integrity sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==
+
+"@esbuild/win32-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz#675b7385398411240735016144ab2e99a60fc75d"
+  integrity sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==
+
+"@esbuild/win32-ia32@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz#1bfc3ce98aa6ca9a0969e4d2af72144c59c1193b"
+  integrity sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==
+
+"@esbuild/win32-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
+  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
+
 "@iarna/toml@2.2.5":
   version "2.2.5"
   resolved "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz"
@@ -25,6 +140,11 @@
   version "1.0.7"
   resolved "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.7.tgz"
   integrity sha512-m+Trk77mp54Zma6xLkLuY+mvanPxlE4A7yNKs2HBiyZ4UkVs28Mv5c/pgWrHeInx+USHeX/WEPzjrWrcJiQgjw==
+
+"@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
 "@lezer/common@^1.0.0":
   version "1.2.3"
@@ -1005,6 +1125,131 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
+"@rollup/rollup-android-arm-eabi@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz#a6742c74c7d9d6d604ef8a48f99326b4ecda3d82"
+  integrity sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==
+
+"@rollup/rollup-android-arm64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz#97247be098de4df0c11971089fd2edf80a5da8cf"
+  integrity sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==
+
+"@rollup/rollup-darwin-arm64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz#674852cf14cf11b8056e0b1a2f4e872b523576cf"
+  integrity sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==
+
+"@rollup/rollup-darwin-x64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz#36dfd7ed0aaf4d9d89d9ef983af72632455b0246"
+  integrity sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==
+
+"@rollup/rollup-freebsd-arm64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz#2f87c2074b4220260fdb52a9996246edfc633c22"
+  integrity sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==
+
+"@rollup/rollup-freebsd-x64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz#9b5a26522a38a95dc06616d1939d4d9a76937803"
+  integrity sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz#86aa4859385a8734235b5e40a48e52d770758c3a"
+  integrity sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==
+
+"@rollup/rollup-linux-arm-musleabihf@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz#cbe70e56e6ece8dac83eb773b624fc9e5a460976"
+  integrity sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==
+
+"@rollup/rollup-linux-arm64-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz#d14992a2e653bc3263d284bc6579b7a2890e1c45"
+  integrity sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==
+
+"@rollup/rollup-linux-arm64-musl@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz#2fdd1ddc434ea90aeaa0851d2044789b4d07f6da"
+  integrity sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==
+
+"@rollup/rollup-linux-loong64-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz#8a181e6f89f969f21666a743cd411416c80099e7"
+  integrity sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==
+
+"@rollup/rollup-linux-loong64-musl@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz#904125af2babc395f8061daa27b5af1f4e3f2f78"
+  integrity sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==
+
+"@rollup/rollup-linux-ppc64-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz#a57970ac6864c9a3447411a658224bdcf948be22"
+  integrity sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==
+
+"@rollup/rollup-linux-ppc64-musl@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz#bb84de5b26870567a4267666e08891e80bb56a63"
+  integrity sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==
+
+"@rollup/rollup-linux-riscv64-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz#72d00d2c7fb375ce3564e759db33f17a35bffab9"
+  integrity sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==
+
+"@rollup/rollup-linux-riscv64-musl@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz#4c166ef58e718f9245bd31873384ba15a5c1a883"
+  integrity sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==
+
+"@rollup/rollup-linux-s390x-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz#bb5025cde9a61db478c2ca7215808ad3bce73a09"
+  integrity sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==
+
+"@rollup/rollup-linux-x64-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz#9b66b1f9cd95c6624c788f021c756269ffed1552"
+  integrity sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==
+
+"@rollup/rollup-linux-x64-musl@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz#b007ca255dc7166017d57d7d2451963f0bd23fd9"
+  integrity sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==
+
+"@rollup/rollup-openbsd-x64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz#e8b357b2d1aa2c8d76a98f5f0d889eabe93f4ef9"
+  integrity sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==
+
+"@rollup/rollup-openharmony-arm64@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz#96c2e3f4aacd3d921981329831ff8dde492204dc"
+  integrity sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==
+
+"@rollup/rollup-win32-arm64-msvc@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz#2d865149d706d938df8b4b8f117e69a77646d581"
+  integrity sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==
+
+"@rollup/rollup-win32-ia32-msvc@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz#abe1593be0fa92325e9971c8da429c5e05b92c36"
+  integrity sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==
+
+"@rollup/rollup-win32-x64-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz#c4af3e9518c9a5cd4b1c163dc81d0ad4d82e7eab"
+  integrity sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==
+
+"@rollup/rollup-win32-x64-msvc@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz#4584a8a87b29188a4c1fe987a9fcf701e256d86c"
+  integrity sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==
+
 "@sindresorhus/merge-streams@^2.1.0":
   version "2.3.0"
   resolved "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz"
@@ -1108,12 +1353,76 @@
   resolved "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@types/estree@1.0.8", "@types/estree@^1.0.0":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
+  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
 "@types/node@^22.8.2":
   version "22.8.2"
   resolved "https://registry.npmjs.org/@types/node/-/node-22.8.2.tgz"
   integrity sha512-NzaRNFV+FZkvK/KLCsNdTvID0SThyrs5SHB6tsD/lajr22FGC73N2QeDPM2wHtVde8mgcXuSsHQkH5cX1pbPLw==
   dependencies:
     undici-types "~6.19.8"
+
+"@vitest/expect@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-2.1.9.tgz#b566ea20d58ea6578d8dc37040d6c1a47ebe5ff8"
+  integrity sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    tinyrainbow "^1.2.0"
+
+"@vitest/mocker@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-2.1.9.tgz#36243b27351ca8f4d0bbc4ef91594ffd2dc25ef5"
+  integrity sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==
+  dependencies:
+    "@vitest/spy" "2.1.9"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.12"
+
+"@vitest/pretty-format@2.1.9", "@vitest/pretty-format@^2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-2.1.9.tgz#434ff2f7611689f9ce70cd7d567eceb883653fdf"
+  integrity sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==
+  dependencies:
+    tinyrainbow "^1.2.0"
+
+"@vitest/runner@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-2.1.9.tgz#cc18148d2d797fd1fd5908d1f1851d01459be2f6"
+  integrity sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==
+  dependencies:
+    "@vitest/utils" "2.1.9"
+    pathe "^1.1.2"
+
+"@vitest/snapshot@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-2.1.9.tgz#24260b93f798afb102e2dcbd7e61c6dfa118df91"
+  integrity sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+
+"@vitest/spy@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-2.1.9.tgz#cb28538c5039d09818b8bfa8edb4043c94727c60"
+  integrity sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==
+  dependencies:
+    tinyspy "^3.0.2"
+
+"@vitest/utils@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-2.1.9.tgz#4f2486de8a54acf7ecbf2c5c24ad7994a680a6c1"
+  integrity sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==
+  dependencies:
+    "@vitest/pretty-format" "2.1.9"
+    loupe "^3.1.2"
+    tinyrainbow "^1.2.0"
 
 abortcontroller-polyfill@^1.1.9:
   version "1.7.5"
@@ -1167,6 +1476,11 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
 
 ast-types@^0.13.4:
   version "0.13.4"
@@ -1285,6 +1599,11 @@ bundle-name@^4.1.0:
   dependencies:
     run-applescript "^7.0.0"
 
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
@@ -1299,6 +1618,17 @@ caniuse-lite@^1.0.30001669:
   version "1.0.30001673"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001673.tgz"
   integrity sha512-WTrjUCSMp3LYX0nE12ECkV0a+e6LC85E0Auz75555/qr78Oc8YWhEPNfDd6SHdtlCMSzqtuXY0uyEMNRcsKpKw==
+
+chai@^5.1.2:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.3.3.tgz#dd3da955e270916a4bd3f625f4b919996ada7e06"
+  integrity sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
 
 chalk@5.3.0, chalk@^5.3.0:
   version "5.3.0"
@@ -1317,6 +1647,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-error@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
+  integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
 chrome-trace-event@^1.0.2, chrome-trace-event@^1.0.3:
   version "1.0.4"
@@ -1474,6 +1809,18 @@ debug@4, debug@^4.3.4:
   dependencies:
     ms "^2.1.3"
 
+debug@^4.3.7:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz"
@@ -1612,6 +1959,40 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-module-lexer@^1.5.4:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
+
+esbuild@^0.21.3:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.21.5.tgz#9ca301b120922959b766360d8ac830da0d02997d"
+  integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.21.5"
+    "@esbuild/android-arm" "0.21.5"
+    "@esbuild/android-arm64" "0.21.5"
+    "@esbuild/android-x64" "0.21.5"
+    "@esbuild/darwin-arm64" "0.21.5"
+    "@esbuild/darwin-x64" "0.21.5"
+    "@esbuild/freebsd-arm64" "0.21.5"
+    "@esbuild/freebsd-x64" "0.21.5"
+    "@esbuild/linux-arm" "0.21.5"
+    "@esbuild/linux-arm64" "0.21.5"
+    "@esbuild/linux-ia32" "0.21.5"
+    "@esbuild/linux-loong64" "0.21.5"
+    "@esbuild/linux-mips64el" "0.21.5"
+    "@esbuild/linux-ppc64" "0.21.5"
+    "@esbuild/linux-riscv64" "0.21.5"
+    "@esbuild/linux-s390x" "0.21.5"
+    "@esbuild/linux-x64" "0.21.5"
+    "@esbuild/netbsd-x64" "0.21.5"
+    "@esbuild/openbsd-x64" "0.21.5"
+    "@esbuild/sunos-x64" "0.21.5"
+    "@esbuild/win32-arm64" "0.21.5"
+    "@esbuild/win32-ia32" "0.21.5"
+    "@esbuild/win32-x64" "0.21.5"
+
 escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz"
@@ -1642,6 +2023,13 @@ estraverse@^5.2.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -1677,6 +2065,11 @@ execa@^5.1.1:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+expect-type@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
+  integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
 external-editor@^3.1.0:
   version "3.1.0"
@@ -1725,6 +2118,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@~2.3.2, fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -2291,6 +2689,11 @@ log-symbols@^6.0.0:
     chalk "^5.3.0"
     is-unicode-supported "^1.3.0"
 
+loupe@^3.1.0, loupe@^3.1.2:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
+  integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
+
 lru-cache@^7.14.1:
   version "7.18.3"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz"
@@ -2300,6 +2703,13 @@ macos-release@^3.1.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/macos-release/-/macos-release-3.3.0.tgz"
   integrity sha512-tPJQ1HeyiU2vRruNGhZ+VleWuMQRro8iFtJxYgnS4NQe+EukKF6aGiIT+7flZhISAt2iaXBCfFGvAyif7/f8nQ==
+
+magic-string@^0.30.12:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 mdn-data@2.0.14:
   version "2.0.14"
@@ -2393,6 +2803,11 @@ mute-stream@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz"
   integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
+
+nanoid@^3.3.11:
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
 netmask@^2.0.2:
   version "2.0.2"
@@ -2655,7 +3070,17 @@ path-type@^5.0.0:
   resolved "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz"
   integrity sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==
 
-picocolors@^1.0.0, picocolors@^1.1.0:
+pathe@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
+  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
+pathval@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
+  integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
+
+picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -2669,6 +3094,15 @@ postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+
+postcss@^8.4.43:
+  version "8.5.8"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.8.tgz#6230ecc8fb02e7a0f6982e53990937857e13f399"
+  integrity sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 posthtml-parser@^0.10.1:
   version "0.10.2"
@@ -2870,6 +3304,40 @@ reusify@^1.0.4:
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rollup@^4.20.0:
+  version "4.59.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.59.0.tgz#cf74edac17c1486f562d728a4d923a694abdf06f"
+  integrity sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==
+  dependencies:
+    "@types/estree" "1.0.8"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.59.0"
+    "@rollup/rollup-android-arm64" "4.59.0"
+    "@rollup/rollup-darwin-arm64" "4.59.0"
+    "@rollup/rollup-darwin-x64" "4.59.0"
+    "@rollup/rollup-freebsd-arm64" "4.59.0"
+    "@rollup/rollup-freebsd-x64" "4.59.0"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.59.0"
+    "@rollup/rollup-linux-arm-musleabihf" "4.59.0"
+    "@rollup/rollup-linux-arm64-gnu" "4.59.0"
+    "@rollup/rollup-linux-arm64-musl" "4.59.0"
+    "@rollup/rollup-linux-loong64-gnu" "4.59.0"
+    "@rollup/rollup-linux-loong64-musl" "4.59.0"
+    "@rollup/rollup-linux-ppc64-gnu" "4.59.0"
+    "@rollup/rollup-linux-ppc64-musl" "4.59.0"
+    "@rollup/rollup-linux-riscv64-gnu" "4.59.0"
+    "@rollup/rollup-linux-riscv64-musl" "4.59.0"
+    "@rollup/rollup-linux-s390x-gnu" "4.59.0"
+    "@rollup/rollup-linux-x64-gnu" "4.59.0"
+    "@rollup/rollup-linux-x64-musl" "4.59.0"
+    "@rollup/rollup-openbsd-x64" "4.59.0"
+    "@rollup/rollup-openharmony-arm64" "4.59.0"
+    "@rollup/rollup-win32-arm64-msvc" "4.59.0"
+    "@rollup/rollup-win32-ia32-msvc" "4.59.0"
+    "@rollup/rollup-win32-x64-gnu" "4.59.0"
+    "@rollup/rollup-win32-x64-msvc" "4.59.0"
+    fsevents "~2.3.2"
+
 run-applescript@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz"
@@ -2930,6 +3398,11 @@ shelljs@0.8.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
@@ -2967,6 +3440,11 @@ socks@^2.8.3:
     ip-address "^9.0.5"
     smart-buffer "^4.2.0"
 
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
 source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
@@ -2986,6 +3464,16 @@ stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+std-env@^3.8.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 stdin-discarder@^0.2.2:
   version "0.2.2"
@@ -3085,6 +3573,31 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz"
   integrity sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==
+
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
+tinypool@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
+
+tinyrainbow@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-1.2.0.tgz#5c57d2fc0fb3d1afd78465c33ca885d04f02abb5"
+  integrity sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==
+
+tinyspy@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-3.0.2.tgz#86dd3cf3d737b15adcf17d7887c84a75201df20a"
+  integrity sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -3189,6 +3702,54 @@ utility-types@^3.10.0:
   resolved "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz"
   integrity sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==
 
+vite-node@2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-2.1.9.tgz#549710f76a643f1c39ef34bdb5493a944e4f895f"
+  integrity sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.7"
+    es-module-lexer "^1.5.4"
+    pathe "^1.1.2"
+    vite "^5.0.0"
+
+vite@^5.0.0:
+  version "5.4.21"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.21.tgz#84a4f7c5d860b071676d39ba513c0d598fdc7027"
+  integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
+  dependencies:
+    esbuild "^0.21.3"
+    postcss "^8.4.43"
+    rollup "^4.20.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@^2:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-2.1.9.tgz#7d01ffd07a553a51c87170b5e80fea3da7fb41e7"
+  integrity sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==
+  dependencies:
+    "@vitest/expect" "2.1.9"
+    "@vitest/mocker" "2.1.9"
+    "@vitest/pretty-format" "^2.1.9"
+    "@vitest/runner" "2.1.9"
+    "@vitest/snapshot" "2.1.9"
+    "@vitest/spy" "2.1.9"
+    "@vitest/utils" "2.1.9"
+    chai "^5.1.2"
+    debug "^4.3.7"
+    expect-type "^1.1.0"
+    magic-string "^0.30.12"
+    pathe "^1.1.2"
+    std-env "^3.8.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.1"
+    tinypool "^1.0.1"
+    tinyrainbow "^1.2.0"
+    vite "^5.0.0"
+    vite-node "2.1.9"
+    why-is-node-running "^2.3.0"
+
 wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz"
@@ -3212,6 +3773,14 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 widest-line@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary

Adds browser support to `git-hash-art` so the library can run in both Node.js and browser environments without any code changes for consumers.

## What changed

### Architecture
- Extracted the pure rendering logic into `src/lib/render.ts` (`renderHashArt`) — uses only the standard `CanvasRenderingContext2D` API, zero environment-specific dependencies
- `src/index.ts` is now the Node-specific entry point (wraps `renderHashArt` with `@napi-rs/canvas`)
- `src/browser.ts` is the new browser entry point with `renderToCanvas`, `generateImageBlob`, and `generateDataURL`
- `src/types.ts` holds the shared `GenerationConfig` interface and `DEFAULT_CONFIG`

### Package changes
- `@napi-rs/canvas` moved from `dependencies` → optional `peerDependencies` (browser consumers don't need it)
- Added `exports` map in `package.json` for conditional Node/browser resolution
- Added Parcel `browser` target → outputs `dist/browser.js` (ESM)

### Docs
- README updated with browser usage examples (vanilla JS, data URLs, Blob downloads, React component)
- Documented the `renderHashArt` core API for advanced/custom canvas setups
- Updated steering files to reflect the new architecture

### Tests
- Added `render.test.ts` for the environment-agnostic core renderer
- All 89 tests pass, build produces all three targets cleanly

## Usage

```js
// Node (unchanged)
import { generateImageFromHash } from 'git-hash-art';

// Browser (new)
import { renderToCanvas } from 'git-hash-art/browser';

// Core renderer (both environments)
import { renderHashArt } from 'git-hash-art'; // or 'git-hash-art/browser'
```