### PR TITLE
feat: artistic enhancements for richer generative output

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -9,22 +9,27 @@ Hash String
   │
   ├─► Seed (mulberry32 PRNG)
   │
-  ├─► Color Scheme (analogic + complementary + triadic palettes)
+  ├─► Color Scheme (hash-driven variation + scheme type selection)
   │
   └─► Rendering Pipeline
        │
-       1. Background Layer
-       2. Composition Mode Selection
-       3. Focal Point Generation
-       4. Flow Field Initialization
-       5. Shape Layers (× N layers)
-       │   ├─ Position (composition mode + focal bias)
+       1.  Background Layer (radial gradient)
+       1b. Layered Background (faint shapes + concentric rings)
+       2.  Composition Mode Selection
+       3.  Focal Points + Void Zones (negative space)
+       4.  Flow Field Initialization
+       5.  Shape Layers (× N layers)
+       │   ├─ Blend Mode (per-layer compositing)
+       │   ├─ Render Style (fill+stroke, wireframe, dashed, watercolor, etc.)
+       │   ├─ Position (composition mode + focal bias + density check)
        │   ├─ Shape Selection (layer-weighted)
+       │   ├─ Atmospheric Depth (desaturation on later layers)
        │   ├─ Styling (transparency, glow, gradients, color jitter)
+       │   ├─ Organic Edges (~15% watercolor bleed)
        │   └─ Recursive Nesting (~15% of large shapes)
-       6. Flow-Line Pass
-       7. Noise Texture Overlay
-       8. Organic Connecting Curves
+       6.  Flow-Line Pass (tapered brush strokes)
+       7.  Noise Texture Overlay
+       8.  Organic Connecting Curves
 ```
 
 ## 1. Deterministic RNG
@@ -44,21 +49,46 @@ The `SacredColorScheme` class derives three harmonious palettes from the hash:
 
 | Palette | Method | Purpose |
 |---------|--------|---------|
-| Base (analogic) | `color-scheme` lib, hue = seed % 360 | Primary shape colors |
-| Complementary (mono) | hue = seed + 180° | Contrast accents |
+| Base | `color-scheme` lib, hue = seed % 360, hash-driven scheme type | Primary shape colors |
+| Complementary | hue = seed + 180°, contrasting variation | Contrast accents |
 | Triadic | hue = seed + 120° | Additional variety |
 
 These are merged and deduplicated into a single 6-8 color palette. Background colors are darkened variants (65% and 55% brightness) of the base scheme.
+
+### Hash-Driven Color Variation
+
+The hash deterministically selects both a **scheme type** and a **color variation**, producing dramatically different palettes from the same hue:
+
+| Variation | Character |
+|-----------|-----------|
+| `soft` | Muted, gentle tones |
+| `hard` | High saturation, vivid |
+| `pastel` | Light, airy |
+| `light` | Bright, open |
+| `dark` | Deep, moody |
+| `default` | Balanced, neutral |
+
+Scheme types also vary: `analogic`, `mono`, `contrast`, `triade`, `tetrade`. The complementary palette uses a contrasting variation (e.g., if base is `soft`, complementary uses `hard`) to create intentional color tension.
 
 ### Color Utilities
 
 - **`hexWithAlpha(hex, alpha)`** — converts hex to `rgba()` for transparency
 - **`jitterColor(hex, rng, amount)`** — applies ±amount RGB jitter per channel for organic variation
+- **`desaturate(hex, amount)`** — blends toward luminance gray for atmospheric depth
 - **Positional blending** — shape fill color is biased by canvas position, creating smooth color flow across the image
 
 ## 3. Background
 
 A radial gradient fills the canvas from center to corners using two darkened base-scheme colors. This creates depth before any shapes are drawn.
+
+### Layered Background
+
+After the gradient, a second pass adds visual texture to the background:
+
+- **Faint shapes** — 3-7 large, very low-opacity circles (3-8% alpha) drawn with `soft-light` blending, creating subtle color pools
+- **Concentric rings** — 2-4 rings emanating from center at ~2-5% opacity, adding structure without competing with foreground shapes
+
+This prevents the background from feeling flat and gives the image depth before the main shape layers begin.
 
 ## 4. Composition Modes
 
@@ -74,9 +104,17 @@ The hash deterministically selects one of five composition strategies that contr
 
 Each mode produces fundamentally different visual character from the same shape set.
 
-## 5. Focal Points
+## 5. Focal Points & Negative Space
 
 1-2 focal points are placed on the canvas (kept away from edges). Every shape position is pulled toward the nearest focal point by a strength factor (30-70%), creating areas of visual density and intentional-looking composition rather than uniform scatter.
+
+### Void Zones (Negative Space)
+
+1-2 void zones are generated at random positions. Shapes that land inside a void zone have an 85% chance of being skipped, creating deliberate areas of breathing room. A few shapes bleed through (15%) to keep the edges organic rather than hard-cut.
+
+### Density Awareness
+
+Before placing each shape, the renderer checks how many shapes already exist nearby. If local density exceeds ~15% of the per-layer shape count, there's a 60% chance the shape is skipped. This prevents areas from becoming an opaque blob and creates natural visual rhythm.
 
 ## 6. Shape Layers
 
@@ -90,6 +128,32 @@ The image is built in N layers (default: 4). Each layer has its own characterist
 | Size scale | Later layers use progressively smaller shapes (×0.85, ×0.70, ×0.55) |
 | Shape weights | Early layers favor basic shapes; later layers favor complex/sacred |
 | Per-shape opacity | Additional random jitter (50-100% of layer opacity) |
+| Blend mode | Each layer gets a hash-derived `globalCompositeOperation` (see below) |
+| Render style | Each layer has a dominant render style; 30% of shapes pick their own |
+| Atmospheric depth | Later layers desaturate colors by up to 30%, simulating distance |
+
+### Blend Modes (Per-Layer Compositing)
+
+Each layer deterministically selects a `globalCompositeOperation` from: `source-over`, `screen`, `multiply`, `overlay`, `soft-light`, `color-dodge`, `color-burn`, `lighter`. There's a 40% chance of `source-over` (default) to keep some images clean, while the other modes create rich color interactions where shapes overlap — the kind of depth that makes output feel painterly rather than stacked.
+
+### Render Styles (Per-Shape Treatment)
+
+Instead of always `fill()` + `stroke()`, each shape gets a rendering treatment:
+
+| Style | Description | Probability |
+|-------|-------------|-------------|
+| `fill-and-stroke` | Classic solid fill with outline | ~29% (weighted) |
+| `fill-only` | Soft shapes with no outline | ~14% |
+| `stroke-only` | Wireframe with ghost fill at 30% alpha | ~14% |
+| `double-stroke` | Outer stroke at 2× width + inner stroke in fill color | ~14% |
+| `dashed` | Dashed outline (5% size dash, 3% gap) | ~14% |
+| `watercolor` | 3-4 slightly offset passes at low opacity for bleed effect | ~14% |
+
+70% of shapes in a layer use the layer's dominant style; 30% pick independently. Additionally, ~15% of `fill-and-stroke` shapes are upgraded to `watercolor` for organic edge effects.
+
+### Atmospheric Depth (Per-Layer Desaturation)
+
+Later layers progressively desaturate their colors (0% on layer 0, up to 30% on the final layer). This simulates atmospheric perspective — distant shapes appear more muted, creating a sense of foreground/background depth.
 
 ### Shape Selection (Layer-Weighted)
 
@@ -124,14 +188,16 @@ Each shape receives:
 - Sized at 15-40% of the parent
 - More transparent than the parent layer
 
-## 7. Flow-Line Pass
+## 7. Flow-Line Pass (Tapered Brush Strokes)
 
 6-16 flowing curves are drawn across the canvas, following the hash-derived vector field:
 
 - Each line starts at a random position and takes 30-70 steps
 - At each step, direction is determined by the flow field angle at that position plus slight random wobble
 - Lines stop if they leave the canvas bounds
-- Drawn at very low opacity (6-16%) with thin strokes for subtle movement
+- **Tapered width** — each line starts at 1-4px and tapers to 20% of its starting width by the end, simulating a brush stroke that lifts off the canvas
+- **Tapered opacity** — alpha also decays along the stroke, creating natural fade-out
+- Individual segments are drawn with `lineCap: "round"` for smooth joins
 
 The flow field is defined by:
 ```

--- a/src/lib/canvas/colors.ts
+++ b/src/lib/canvas/colors.ts
@@ -1,69 +1,88 @@
 import ColorScheme from "color-scheme";
 import "../../../global.d";
 
-import { gitHashToSeed } from "../utils";
+import { gitHashToSeed, createRng, seedFromHash } from "../utils";
+
+// ── Color variation modes ───────────────────────────────────────────
+// The hash deterministically selects a variation, producing dramatically
+// different palettes from the same hue.
+
+const COLOR_VARIATIONS = [
+  "soft",
+  "hard",
+  "pastel",
+  "light",
+  "dark",
+  "default",
+] as const;
+type ColorVariation = (typeof COLOR_VARIATIONS)[number];
 
 /**
- * Generates a color scheme based on a given Git hash.
+ * Pick a color variation mode deterministically from a seed.
  */
-export function generateColorScheme(gitHash: string): string[] {
-  const seed = gitHashToSeed(gitHash);
-  const scheme = new ColorScheme();
-  scheme
-    .from_hue(seed % 360)
-    .scheme("analogic")
-    .variation("soft");
-
-  let colors = scheme.colors().map((hex: string) => `#${hex}`);
-
-  const contrastingHue = (seed + 180) % 360;
-  const contrastingScheme = new ColorScheme();
-  contrastingScheme.from_hue(contrastingHue).scheme("mono").variation("soft");
-  colors.push(`#${contrastingScheme.colors()[0]}`);
-
-  return colors;
+function pickVariation(seed: number): ColorVariation {
+  return COLOR_VARIATIONS[Math.abs(seed) % COLOR_VARIATIONS.length];
 }
 
-interface MetallicColors {
-  gold: string;
-  silver: string;
-  copper: string;
-  bronze: string;
+/**
+ * Scheme type also varies — some hashes get near-monochromatic palettes,
+ * others get high-contrast complementary schemes.
+ */
+const SCHEME_TYPES = [
+  "analogic",
+  "mono",
+  "contrast",
+  "triade",
+  "tetrade",
+] as const;
+type SchemeType = (typeof SCHEME_TYPES)[number];
+
+function pickSchemeType(seed: number): SchemeType {
+  return SCHEME_TYPES[Math.abs(seed >> 4) % SCHEME_TYPES.length];
 }
+
 
 // Enhanced color scheme generation for sacred geometry
 export class SacredColorScheme {
   private seed: number;
+  private rng: () => number;
+  private variation: ColorVariation;
+  private schemeType: SchemeType;
   public baseScheme: string[];
   private complementaryScheme: string[];
   private triadicScheme: string[];
-  private metallic: MetallicColors;
 
   constructor(gitHash: string) {
     this.seed = gitHashToSeed(gitHash);
+    this.rng = createRng(seedFromHash(gitHash, 42));
+    // Hash-driven variation and scheme type for palette diversity
+    this.variation = pickVariation(this.seed);
+    this.schemeType = pickSchemeType(this.seed);
     this.baseScheme = this.generateBaseScheme();
     this.complementaryScheme = this.generateComplementaryScheme();
     this.triadicScheme = this.generateTriadicScheme();
-    this.metallic = this.generateMetallicColors();
   }
 
   private generateBaseScheme(): string[] {
     const scheme = new ColorScheme();
     return scheme
       .from_hue(this.seed % 360)
-      .scheme("analogic")
-      .variation("soft")
+      .scheme(this.schemeType)
+      .variation(this.variation)
       .colors()
       .map((hex: string) => `#${hex}`);
   }
 
   private generateComplementaryScheme(): string[] {
     const complementaryHue = (this.seed + 180) % 360;
+    // Complementary uses a contrasting variation for tension
+    const compVariation =
+      this.variation === "soft" ? "hard" : this.variation === "dark" ? "light" : this.variation;
     const scheme = new ColorScheme();
     return scheme
       .from_hue(complementaryHue)
       .scheme("mono")
-      .variation("soft")
+      .variation(compVariation)
       .colors()
       .map((hex: string) => `#${hex}`);
   }
@@ -74,18 +93,9 @@ export class SacredColorScheme {
     return scheme
       .from_hue(triadicHue)
       .scheme("triade")
-      .variation("soft")
+      .variation(this.variation)
       .colors()
       .map((hex: string) => `#${hex}`);
-  }
-
-  private generateMetallicColors(): MetallicColors {
-    return {
-      gold: "#FFD700",
-      silver: "#C0C0C0",
-      copper: "#B87333",
-      bronze: "#CD7F32",
-    };
   }
 
   /**
@@ -165,4 +175,15 @@ export function jitterColor(
   const [r, g, b] = hexToRgb(hex);
   const jit = () => (rng() - 0.5) * 2 * amount * 255;
   return rgbToHex(r + jit(), g + jit(), b + jit());
+}
+
+/**
+ * Desaturate a hex color by blending toward its luminance gray.
+ * `amount` 0 = unchanged, 1 = fully gray.
+ */
+export function desaturate(hex: string, amount: number): string {
+  const [r, g, b] = hexToRgb(hex);
+  const gray = 0.299 * r + 0.587 * g + 0.114 * b;
+  const mix = (c: number) => c + (gray - c) * amount;
+  return rgbToHex(mix(r), mix(g), mix(b));
 }

--- a/src/lib/canvas/draw.ts
+++ b/src/lib/canvas/draw.ts
@@ -1,6 +1,56 @@
 import { PatternCombiner, ProportionType } from "../utils";
 import { shapes } from "./shapes";
 
+// ── Blend modes for layer-level compositing (Feature B) ─────────────
+// These are all standard Canvas 2D globalCompositeOperation values,
+// safe in both Node (@napi-rs/canvas) and browsers.
+
+export const BLEND_MODES: GlobalCompositeOperation[] = [
+  "source-over", // default — safe fallback
+  "screen",
+  "multiply",
+  "overlay",
+  "soft-light",
+  "color-dodge",
+  "color-burn",
+  "lighter",
+];
+
+/**
+ * Pick a blend mode deterministically from the RNG.
+ * ~40% chance of default source-over to keep some images clean.
+ */
+export function pickBlendMode(rng: () => number): GlobalCompositeOperation {
+  if (rng() < 0.4) return "source-over";
+  return BLEND_MODES[1 + Math.floor(rng() * (BLEND_MODES.length - 1))];
+}
+
+// ── Shape rendering styles (Feature C) ──────────────────────────────
+
+export type RenderStyle =
+  | "fill-and-stroke"  // classic (current behavior)
+  | "fill-only"        // soft, no outline
+  | "stroke-only"      // wireframe
+  | "double-stroke"    // inner + outer stroke
+  | "dashed"           // dashed outline
+  | "watercolor";      // multiple offset passes at low opacity
+
+const RENDER_STYLES: RenderStyle[] = [
+  "fill-and-stroke",
+  "fill-and-stroke",  // weighted: appears twice for higher probability
+  "fill-only",
+  "stroke-only",
+  "double-stroke",
+  "dashed",
+  "watercolor",
+];
+
+export function pickRenderStyle(rng: () => number): RenderStyle {
+  return RENDER_STYLES[Math.floor(rng() * RENDER_STYLES.length)];
+}
+
+// ── Config interfaces ───────────────────────────────────────────────
+
 interface DrawShapeConfig {
   fillColor: string;
   strokeColor: string;
@@ -19,6 +69,10 @@ interface EnhanceShapeConfig extends DrawShapeConfig {
   glowColor?: string;
   /** If provided, fills with a radial gradient between two colors. */
   gradientFillEnd?: string;
+  /** Rendering style — controls fill/stroke treatment. */
+  renderStyle?: RenderStyle;
+  /** RNG for watercolor jitter (required for "watercolor" style). */
+  rng?: () => number;
 }
 
 export function drawShape(
@@ -47,7 +101,83 @@ export function drawShape(
 }
 
 /**
- * Enhanced shape drawing with glow, gradient fills, and pattern layering.
+ * Apply the chosen render style to the current path.
+ */
+function applyRenderStyle(
+  ctx: CanvasRenderingContext2D,
+  style: RenderStyle,
+  fillColor: string,
+  strokeColor: string,
+  strokeWidth: number,
+  size: number,
+  rng?: () => number,
+): void {
+  switch (style) {
+    case "fill-only":
+      ctx.fill();
+      break;
+
+    case "stroke-only":
+      ctx.fill(); // transparent fill to define the path
+      ctx.globalAlpha *= 0.3; // ghost fill
+      ctx.fill();
+      ctx.globalAlpha /= 0.3;
+      ctx.stroke();
+      break;
+
+    case "double-stroke": {
+      ctx.fill();
+      // Outer stroke
+      ctx.lineWidth = strokeWidth * 2;
+      ctx.globalAlpha *= 0.5;
+      ctx.stroke();
+      ctx.globalAlpha /= 0.5;
+      // Inner stroke
+      ctx.lineWidth = strokeWidth * 0.5;
+      ctx.strokeStyle = fillColor;
+      ctx.stroke();
+      break;
+    }
+
+    case "dashed":
+      ctx.fill();
+      ctx.setLineDash([size * 0.05, size * 0.03]);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      break;
+
+    case "watercolor": {
+      // Draw 3-4 slightly offset passes at low opacity for a bleed effect
+      const passes = 3 + (rng ? Math.floor(rng() * 2) : 0);
+      const savedAlpha = ctx.globalAlpha;
+      ctx.globalAlpha = savedAlpha * (0.3 / passes * 2);
+      for (let p = 0; p < passes; p++) {
+        const jx = rng ? (rng() - 0.5) * size * 0.06 : 0;
+        const jy = rng ? (rng() - 0.5) * size * 0.06 : 0;
+        ctx.save();
+        ctx.translate(jx, jy);
+        ctx.fill();
+        ctx.restore();
+      }
+      ctx.globalAlpha = savedAlpha;
+      // Light stroke on top
+      ctx.globalAlpha *= 0.4;
+      ctx.stroke();
+      ctx.globalAlpha /= 0.4;
+      break;
+    }
+
+    case "fill-and-stroke":
+    default:
+      ctx.fill();
+      ctx.stroke();
+      break;
+  }
+}
+
+/**
+ * Enhanced shape drawing with glow, gradient fills, blend modes,
+ * render style variety, and pattern layering.
  */
 export function enhanceShapeGeneration(
   ctx: CanvasRenderingContext2D,
@@ -69,6 +199,8 @@ export function enhanceShapeGeneration(
     glowRadius = 0,
     glowColor,
     gradientFillEnd,
+    renderStyle = "fill-and-stroke",
+    rng,
   } = config;
 
   ctx.save();
@@ -99,8 +231,7 @@ export function enhanceShapeGeneration(
   const drawFunction = shapes[shape];
   if (drawFunction) {
     drawFunction(ctx, size);
-    ctx.fill();
-    ctx.stroke();
+    applyRenderStyle(ctx, renderStyle, fillColor, strokeColor, strokeWidth, size, rng);
   }
 
   // Reset shadow so patterns aren't double-glowed

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -5,17 +5,29 @@
  * identically in Node (@napi-rs/canvas) and browsers.
  *
  * Generation pipeline:
- *   1. Background — radial gradient from hash-derived dark palette
- *   2. Composition mode — hash selects: radial, flow-field, spiral, grid-subdivision, or clustered
- *   3. Color field — smooth positional color blending across the canvas
- *   4. Shape layers — weighted selection, focal-point placement, transparency, glow, gradients, jitter
- *   5. Recursive nesting — some shapes contain smaller shapes inside
- *   6. Flow-line pass — bezier curves following a hash-derived vector field
- *   7. Noise texture overlay — subtle grain for organic feel
- *   8. Organic connecting curves — beziers between nearby shapes
+ *   1.  Background — radial gradient from hash-derived dark palette
+ *   1b. Layered background — large faint shapes / subtle pattern for depth
+ *   2.  Composition mode — hash selects: radial, flow-field, spiral, grid-subdivision, or clustered
+ *   3.  Focal points + void zones (negative space)
+ *   4.  Flow field seed values
+ *   5.  Shape layers — blend modes, render styles, weighted selection,
+ *       focal-point placement, atmospheric depth, organic edges
+ *   5b. Recursive nesting
+ *   6.  Flow-line pass — tapered brush-stroke curves
+ *   7.  Noise texture overlay
+ *   8.  Organic connecting curves
  */
-import { SacredColorScheme, hexWithAlpha, jitterColor } from "./canvas/colors";
-import { enhanceShapeGeneration } from "./canvas/draw";
+import {
+    SacredColorScheme,
+    hexWithAlpha,
+    jitterColor,
+    desaturate,
+} from "./canvas/colors";
+import {
+    enhanceShapeGeneration,
+    pickBlendMode,
+    pickRenderStyle,
+} from "./canvas/draw";
 import { shapes } from "./canvas/shapes";
 import { createRng, seedFromHash } from "./utils";
 import { DEFAULT_CONFIG, type GenerationConfig } from "../types";
@@ -95,26 +107,6 @@ function pickShape(
   return available[Math.floor(rng() * available.length)];
 }
 
-// ── Helper: simple 2D value noise (hash-seeded) ─────────────────────
-
-function valueNoise(
-  x: number,
-  y: number,
-  scale: number,
-  rng: () => number,
-): number {
-  // Cheap pseudo-noise: combine sin waves at different frequencies
-  const nx = x / scale;
-  const ny = y / scale;
-  return (
-    (Math.sin(nx * 1.7 + ny * 2.3 + rng() * 0.001) * 0.5 +
-      Math.sin(nx * 3.1 - ny * 1.9 + rng() * 0.001) * 0.3 +
-      Math.sin(nx * 5.3 + ny * 4.7 + rng() * 0.001) * 0.2) *
-      0.5 +
-    0.5
-  );
-}
-
 // ── Helper: get position based on composition mode ──────────────────
 
 function getCompositionPosition(
@@ -154,10 +146,8 @@ function getCompositionPosition(
       };
     }
     case "clustered": {
-      // Pick one of 3-5 cluster centers, then scatter around it
       const numClusters = 3 + Math.floor(rng() * 3);
       const ci = Math.floor(rng() * numClusters);
-      // Deterministic cluster center from index
       const clusterRng = createRng(seedFromHash(String(ci), 999));
       const clx = width * (0.15 + clusterRng() * 0.7);
       const cly = height * (0.15 + clusterRng() * 0.7);
@@ -169,7 +159,6 @@ function getCompositionPosition(
     }
     case "flow-field":
     default: {
-      // Random position, will be adjusted by flow field direction later
       return { x: rng() * width, y: rng() * height };
     }
   }
@@ -185,14 +174,39 @@ function getPositionalColor(
   colors: string[],
   rng: () => number,
 ): string {
-  // Blend between palette colors based on position
   const nx = x / width;
   const ny = y / height;
-  // Use position to bias which palette color is chosen
   const posIndex = (nx * 0.6 + ny * 0.4) * (colors.length - 1);
   const baseIdx = Math.floor(posIndex) % colors.length;
-  // Then jitter it slightly
   return jitterColor(colors[baseIdx], rng, 0.08);
+}
+
+// ── Helper: check if a position is inside a void zone (Feature E) ───
+
+function isInVoidZone(
+  x: number,
+  y: number,
+  voidZones: Array<{ x: number; y: number; radius: number }>,
+): boolean {
+  for (const zone of voidZones) {
+    if (Math.hypot(x - zone.x, y - zone.y) < zone.radius) return true;
+  }
+  return false;
+}
+
+// ── Helper: density check for negative space (Feature E) ────────────
+
+function localDensity(
+  x: number,
+  y: number,
+  positions: Array<{ x: number; y: number; size: number }>,
+  radius: number,
+): number {
+  let count = 0;
+  for (const p of positions) {
+    if (Math.hypot(x - p.x, y - p.y) < radius) count++;
+  }
+  return count;
 }
 
 // ── Main render function ────────────────────────────────────────────
@@ -238,11 +252,39 @@ export function renderHashArt(
   ctx.fillStyle = bgGrad;
   ctx.fillRect(0, 0, width, height);
 
+  // ── 1b. Layered background (Feature G) ─────────────────────────
+  // Draw large, very faint shapes to give the background texture
+  const bgShapeCount = 3 + Math.floor(rng() * 4);
+  ctx.globalCompositeOperation = "soft-light";
+  for (let i = 0; i < bgShapeCount; i++) {
+    const bx = rng() * width;
+    const by = rng() * height;
+    const bSize = (width * 0.3 + rng() * width * 0.5);
+    const bColor = colors[Math.floor(rng() * colors.length)];
+    ctx.globalAlpha = 0.03 + rng() * 0.05;
+    ctx.fillStyle = hexWithAlpha(bColor, 0.15);
+    ctx.beginPath();
+    ctx.arc(bx, by, bSize / 2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  // Subtle concentric rings from center
+  const ringCount = 2 + Math.floor(rng() * 3);
+  ctx.globalAlpha = 0.02 + rng() * 0.03;
+  ctx.strokeStyle = hexWithAlpha(colors[0], 0.1);
+  ctx.lineWidth = 1 * scaleFactor;
+  for (let i = 1; i <= ringCount; i++) {
+    const r = (Math.min(width, height) * 0.15) * i;
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.globalCompositeOperation = "source-over";
+
   // ── 2. Composition mode ────────────────────────────────────────
   const compositionMode =
     COMPOSITION_MODES[Math.floor(rng() * COMPOSITION_MODES.length)];
 
-  // ── 3. Focal points ────────────────────────────────────────────
+  // ── 3. Focal points + void zones ───────────────────────────────
   const numFocal = 1 + Math.floor(rng() * 2);
   const focalPoints: Array<{ x: number; y: number; strength: number }> = [];
   for (let f = 0; f < numFocal; f++) {
@@ -250,6 +292,17 @@ export function renderHashArt(
       x: width * (0.2 + rng() * 0.6),
       y: height * (0.2 + rng() * 0.6),
       strength: 0.3 + rng() * 0.4,
+    });
+  }
+
+  // Feature E: 1-2 void zones where shapes are sparse (negative space)
+  const numVoids = Math.floor(rng() * 2) + 1;
+  const voidZones: Array<{ x: number; y: number; radius: number }> = [];
+  for (let v = 0; v < numVoids; v++) {
+    voidZones.push({
+      x: width * (0.15 + rng() * 0.7),
+      y: height * (0.15 + rng() * 0.7),
+      radius: Math.min(width, height) * (0.06 + rng() * 0.1),
     });
   }
 
@@ -267,7 +320,7 @@ export function renderHashArt(
     return [rx + (nearest.x - rx) * pull, ry + (nearest.y - ry) * pull];
   }
 
-  // ── 4. Flow field seed values (for flow-field mode & line pass) ─
+  // ── 4. Flow field seed values ──────────────────────────────────
   const fieldAngleBase = rng() * Math.PI * 2;
   const fieldFreq = 0.5 + rng() * 2;
 
@@ -281,6 +334,8 @@ export function renderHashArt(
 
   // ── 5. Shape layers ────────────────────────────────────────────
   const shapePositions: Array<{ x: number; y: number; size: number }> = [];
+  const densityCheckRadius = Math.min(width, height) * 0.08;
+  const maxLocalDensity = Math.ceil(finalConfig.shapesPerLayer * 0.15);
 
   for (let layer = 0; layer < layers; layer++) {
     const layerRatio = layers > 1 ? layer / (layers - 1) : 0;
@@ -289,6 +344,16 @@ export function renderHashArt(
       Math.floor(rng() * finalConfig.shapesPerLayer * 0.3);
     const layerOpacity = Math.max(0.15, baseOpacity - layer * opacityReduction);
     const layerSizeScale = 1 - layer * 0.15;
+
+    // Feature B: per-layer blend mode
+    const layerBlend = pickBlendMode(rng);
+    ctx.globalCompositeOperation = layerBlend;
+
+    // Feature C: per-layer render style bias
+    const layerRenderStyle = pickRenderStyle(rng);
+
+    // Feature D: atmospheric desaturation for later layers
+    const atmosphericDesat = layerRatio * 0.3; // 0 for first layer, up to 0.3 for last
 
     for (let i = 0; i < numShapes; i++) {
       // Position from composition mode, then focal bias
@@ -303,6 +368,15 @@ export function renderHashArt(
         cy,
       );
       const [x, y] = applyFocalBias(rawPos.x, rawPos.y);
+
+      // Feature E: skip shapes in void zones, reduce in dense areas
+      if (isInVoidZone(x, y, voidZones)) {
+        // 85% chance to skip — allows a few shapes to bleed in
+        if (rng() < 0.85) continue;
+      }
+      if (localDensity(x, y, shapePositions, densityCheckRadius) > maxLocalDensity) {
+        if (rng() < 0.6) continue; // thin out dense areas
+      }
 
       // Weighted shape selection
       const shape = pickShape(rng, layerRatio, shapeNames);
@@ -320,8 +394,14 @@ export function renderHashArt(
           : rng() * 360;
 
       // Positional color blending + jitter
-      const fillBase = getPositionalColor(x, y, width, height, colors, rng);
+      let fillBase = getPositionalColor(x, y, width, height, colors, rng);
       const strokeBase = colors[Math.floor(rng() * colors.length)];
+
+      // Feature D: desaturate colors on later layers for depth
+      if (atmosphericDesat > 0) {
+        fillBase = desaturate(fillBase, atmosphericDesat);
+      }
+
       const fillColor = jitterColor(fillBase, rng, 0.06);
       const strokeColor = jitterColor(strokeBase, rng, 0.05);
 
@@ -345,6 +425,14 @@ export function renderHashArt(
         ? jitterColor(colors[Math.floor(rng() * colors.length)], rng, 0.1)
         : undefined;
 
+      // Feature C: per-shape render style (70% use layer style, 30% pick their own)
+      const shapeRenderStyle =
+        rng() < 0.7 ? layerRenderStyle : pickRenderStyle(rng);
+
+      // Feature F: organic edge jitter — applied via watercolor style on ~15% of shapes
+      const useOrganicEdges = rng() < 0.15 && shapeRenderStyle === "fill-and-stroke";
+      const finalRenderStyle = useOrganicEdges ? "watercolor" : shapeRenderStyle;
+
       enhanceShapeGeneration(ctx, shape, x, y, {
         fillColor: transparentFill,
         strokeColor,
@@ -355,11 +443,13 @@ export function renderHashArt(
         glowRadius,
         glowColor: hasGlow ? hexWithAlpha(fillColor, 0.6) : undefined,
         gradientFillEnd: gradientEnd,
+        renderStyle: finalRenderStyle,
+        rng,
       });
 
       shapePositions.push({ x, y, size });
 
-      // ── 5b. Recursive nesting: ~15% of larger shapes get inner shapes ──
+      // ── 5b. Recursive nesting ──────────────────────────────────
       if (size > adjustedMaxSize * 0.4 && rng() < 0.15) {
         const innerCount = 1 + Math.floor(rng() * 3);
         for (let n = 0; n < innerCount; n++) {
@@ -390,6 +480,8 @@ export function renderHashArt(
               size: innerSize,
               rotation: innerRot,
               proportionType: "GOLDEN_RATIO",
+              renderStyle: shapeRenderStyle,
+              rng,
             },
           );
         }
@@ -397,39 +489,52 @@ export function renderHashArt(
     }
   }
 
-  // ── 6. Flow-line pass ──────────────────────────────────────────
-  // Draw flowing curves that follow the hash-derived vector field
+  // Reset blend mode for post-processing passes
+  ctx.globalCompositeOperation = "source-over";
+
+  // ── 6. Flow-line pass (Feature H: tapered brush strokes) ───────
   const numFlowLines = 6 + Math.floor(rng() * 10);
   for (let i = 0; i < numFlowLines; i++) {
     let fx = rng() * width;
     let fy = rng() * height;
     const steps = 30 + Math.floor(rng() * 40);
     const stepLen = (3 + rng() * 5) * scaleFactor;
+    const startWidth = (1 + rng() * 3) * scaleFactor;
 
-    ctx.globalAlpha = 0.06 + rng() * 0.1;
-    ctx.strokeStyle = hexWithAlpha(
+    const lineColor = hexWithAlpha(
       colors[Math.floor(rng() * colors.length)],
       0.4,
     );
-    ctx.lineWidth = (0.5 + rng() * 1.5) * scaleFactor;
+    const lineAlpha = 0.06 + rng() * 0.1;
 
-    ctx.beginPath();
-    ctx.moveTo(fx, fy);
-
+    // Draw as individual segments with tapering width
+    let prevX = fx;
+    let prevY = fy;
     for (let s = 0; s < steps; s++) {
       const angle = flowAngle(fx, fy) + (rng() - 0.5) * 0.3;
       fx += Math.cos(angle) * stepLen;
       fy += Math.sin(angle) * stepLen;
 
-      // Stay in bounds
       if (fx < 0 || fx > width || fy < 0 || fy > height) break;
+
+      // Taper: thick at start, thin at end
+      const taper = 1 - (s / steps) * 0.8;
+      ctx.globalAlpha = lineAlpha * taper;
+      ctx.strokeStyle = lineColor;
+      ctx.lineWidth = startWidth * taper;
+      ctx.lineCap = "round";
+
+      ctx.beginPath();
+      ctx.moveTo(prevX, prevY);
       ctx.lineTo(fx, fy);
+      ctx.stroke();
+
+      prevX = fx;
+      prevY = fy;
     }
-    ctx.stroke();
   }
 
   // ── 7. Noise texture overlay ───────────────────────────────────
-  // Subtle grain rendered as tiny semi-transparent dots
   const noiseRng = createRng(seedFromHash(gitHash, 777));
   const noiseDensity = Math.floor((width * height) / 800);
   for (let i = 0; i < noiseDensity; i++) {


### PR DESCRIPTION
## Summary

Eight artistic enhancements to the rendering pipeline that significantly increase visual diversity and creative quality of generated images. All changes are deterministic — same hash still produces the same image.

## Changes

### A. Color Variation Modes (`colors.ts`)
Hash now selects from 6 color variations (`soft`, `hard`, `pastel`, `light`, `dark`, `default`) and 5 scheme types (`analogic`, `mono`, `contrast`, `triade`, `tetrade`). Complementary palettes use a contrasting variation for intentional color tension.

### B. Per-Layer Blend Modes (`draw.ts`, `render.ts`)
Each layer gets a hash-derived `globalCompositeOperation` (`screen`, `multiply`, `overlay`, `soft-light`, `color-dodge`, `color-burn`, `lighter`). 40% chance of default `source-over` to keep some images clean.

### C. Shape Rendering Variety (`draw.ts`, `render.ts`)
Six render styles: `fill-and-stroke`, `fill-only`, `stroke-only`, `double-stroke`, `dashed`, `watercolor`. 70% of shapes follow the layer's dominant style, 30% pick independently.

### D. Atmospheric Depth (`render.ts`, `colors.ts`)
Later layers desaturate colors up to 30% via new `desaturate()` utility, simulating distance and creating foreground/background separation.

### E. Negative Space (`render.ts`)
Void zones (85% shape skip rate) and density-aware placement (60% skip in crowded areas) create deliberate breathing room and visual rhythm.

### F. Organic Edges (`render.ts`)
~15% of standard shapes get upgraded to `watercolor` style (3-4 offset passes at low opacity for bleed effect).

### G. Layered Background (`render.ts`)
Faint circles with `soft-light` blending and concentric rings add texture before the main shape layers.

### H. Tapered Flow Lines (`render.ts`)
Flow lines draw as individual segments with decreasing width and opacity, simulating brush strokes.

## Testing

All 89 existing tests pass. No new dependencies added.