### PR TITLE
feat: procedural shape generators and contrast enforcement

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -11,12 +11,13 @@ Hash String
   │
   ├─► Archetype Selection (1 of 10 visual personalities)
   │
-  ├─► Color Scheme (palette mode from archetype + temperature mode)
+  ├─► Color Scheme (palette mode from archetype + temperature mode + contrast enforcement)
   │
   └─► Rendering Pipeline (parameters overridden by archetype)
        │
        0.  Archetype Override (gridSize, layers, opacity, sizes, styles)
        1.  Background Layer (7 styles: radial, linear, solid, multi-stop)
+       1a. Background Luminance → contrast enforcement threshold
        1b. Layered Background (faint shapes + concentric rings)
        2.  Composition Mode Selection
        2b. Symmetry Mode Selection (none / bilateral / quad)
@@ -27,7 +28,8 @@ Hash String
        │   ├─ Blend Mode (per-layer compositing)
        │   ├─ Render Style (archetype-preferred + random mix)
        │   ├─ Position (composition mode + focal bias + density check)
-       │   ├─ Shape Selection (layer-weighted)
+       │   ├─ Shape Selection (4 categories: basic, complex, sacred, procedural)
+       │   ├─ Contrast Enforcement (ensure readability vs background)
        │   ├─ Atmospheric Depth (desaturation on later layers)
        │   ├─ Temperature Contrast (foreground opposite to background)
        │   ├─ Styling (transparency, glow, gradients, color jitter)
@@ -267,13 +269,25 @@ Later layers progressively desaturate their colors (0% on layer 0, up to 30% on 
 
 ### Shape Selection (Layer-Weighted)
 
-Shapes are divided into three categories with weights that shift across layers:
+Shapes are divided into four categories with weights that shift across layers:
 
 | Category | Shapes | Early layers | Late layers |
 |----------|--------|-------------|-------------|
 | **Basic** | circle, square, triangle, hexagon, diamond, cube | High weight | Low weight |
 | **Complex** | star, platonic solid, fibonacci spiral, islamic pattern, celtic knot, merkaba, fractal | Medium | Medium-high |
 | **Sacred** | mandala, flower of life, tree of life, Metatron's cube, Sri Yantra, seed of life, vesica piscis, torus, egg of life | Low | High |
+| **Procedural** | blob, ngon, lissajous, superellipse, spirograph, waveRing, rose | Medium (always present) | Medium-high |
+
+Procedural shapes are hash-derived — their geometry is generated from the RNG, so every hash produces unique shapes that don't exist in any other generation. See the Procedural Shapes section below for details.
+
+### Contrast Enforcement
+
+After color selection, every foreground color (fills, strokes, flow lines, connecting curves) is checked against the average background luminance. If the luminance difference is below the minimum threshold (0.15), the color is adjusted:
+
+- **Light backgrounds** — foreground colors are darkened and saturated
+- **Dark backgrounds** — foreground colors are lightened and saturated
+
+This prevents the white-on-white and dark-on-dark readability problems that occur when light palette modes (pastel-light, high-contrast) combine with light background styles (solid-light, radial-light).
 
 ### Size Distribution
 
@@ -365,6 +379,19 @@ Mathematically precise sacred geometry patterns:
 - **Vesica Piscis** — two overlapping circles
 - **Torus** — 2D projection of a torus via line segments
 - **Egg of Life** — 7 circles in tight hexagonal packing
+
+### Procedural Shapes
+Hash-derived shapes whose geometry is generated from the RNG. Every hash produces unique shapes that don't exist in any other generation:
+
+| Shape | Algorithm | Hash Controls |
+|-------|-----------|---------------|
+| **Blob** | Smooth closed curve via quadratic bezier through 5-9 control points arranged around a circle | Number of lobes (5-9), radius jitter per lobe (50-100%) |
+| **Ngon** | Irregular polygon with independent vertex displacement | Side count (3-12), vertex jitter amount (10-50%) |
+| **Lissajous** | Parametric curve `x = sin(a*t + φ), y = sin(b*t)` | Frequency ratios a,b (1-5 each), phase offset φ |
+| **Superellipse** | `|x|^n + |y|^n = 1` rendered parametrically | Exponent n: 0.3 (spiky astroid) → 2 (circle) → 5 (rounded rectangle) |
+| **Spirograph** | Hypotrochoid curve `(R-r)cos(t) + d*cos((R-r)t/r)` | Inner radius ratio r (0.2-0.8), pen distance d (0.3-1.0) |
+| **Wave Ring** | Concentric rings with sinusoidal radial displacement | Ring count (2-5), wave frequency (3-14), amplitude (5-20%) |
+| **Rose** | Polar rose curve `r = cos(k*θ)` | Petal parameter k (2-7), producing k or 2k petals |
 
 ## Configuration
 

--- a/src/lib/canvas/colors.ts
+++ b/src/lib/canvas/colors.ts
@@ -357,3 +357,48 @@ export function shiftTemperature(hex: string, target: "warm" | "cool", amount: n
   const [h, s, l] = hexToHsl(hex);
   return hslToHex(shiftHueToward(h, target, amount), s, l);
 }
+
+/**
+ * Compute relative luminance of a hex color (0 = black, 1 = white).
+ * Uses the sRGB luminance formula from WCAG.
+ */
+export function luminance(hex: string): number {
+  const [r, g, b] = hexToRgb(hex).map((c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * Enforce minimum contrast between a foreground color and a background
+ * luminance. On light backgrounds, darkens/saturates the foreground.
+ * On dark backgrounds, lightens/saturates the foreground.
+ *
+ * `bgLuminance` is 0-1 (pre-computed from the background color).
+ * `minContrast` is the minimum luminance difference to enforce (default 0.15).
+ */
+export function enforceContrast(
+  fgHex: string,
+  bgLuminance: number,
+  minContrast = 0.15,
+): string {
+  const fgLum = luminance(fgHex);
+  const diff = Math.abs(fgLum - bgLuminance);
+
+  if (diff >= minContrast) return fgHex;
+
+  const [h, s, l] = hexToHsl(fgHex);
+
+  if (bgLuminance > 0.5) {
+    // Light background — darken and boost saturation
+    const targetL = Math.max(0.08, l - (minContrast - diff) * 1.5);
+    const targetS = Math.min(1, s + 0.2);
+    return hslToHex(h, targetS, targetL);
+  } else {
+    // Dark background — lighten and boost saturation
+    const targetL = Math.min(0.92, l + (minContrast - diff) * 1.5);
+    const targetS = Math.min(1, s + 0.15);
+    return hslToHex(h, targetS, targetL);
+  }
+}

--- a/src/lib/canvas/draw.ts
+++ b/src/lib/canvas/draw.ts
@@ -304,7 +304,7 @@ export function enhanceShapeGeneration(
 
   const drawFunction = shapes[shape];
   if (drawFunction) {
-    drawFunction(ctx, size);
+    drawFunction(ctx, size, { rng });
     applyRenderStyle(ctx, renderStyle, fillColor, strokeColor, strokeWidth, size, rng);
   }
 

--- a/src/lib/canvas/shapes/index.ts
+++ b/src/lib/canvas/shapes/index.ts
@@ -1,6 +1,7 @@
 import { basicShapes } from "./basic";
 import { complexShapes } from "./complex";
 import { sacredShapes } from "./sacred";
+import { proceduralShapes } from "./procedural";
 
 type DrawFunction = (
   ctx: CanvasRenderingContext2D,
@@ -12,4 +13,5 @@ export const shapes: Record<string, DrawFunction> = {
   ...basicShapes,
   ...complexShapes,
   ...sacredShapes,
+  ...proceduralShapes,
 };

--- a/src/lib/canvas/shapes/procedural.ts
+++ b/src/lib/canvas/shapes/procedural.ts
@@ -1,0 +1,209 @@
+/**
+ * Procedural shape generators — hash-derived shapes that are unique
+ * per generation. Unlike the fixed shape library, these produce geometry
+ * that doesn't repeat across hashes.
+ *
+ * All draw functions accept an RNG via the config parameter so the
+ * shapes are deterministic from the hash.
+ */
+
+type DrawFunction = (
+  ctx: CanvasRenderingContext2D,
+  size: number,
+  config?: any,
+) => void;
+
+// ── Blob: organic closed curve via cubic bezier ─────────────────────
+// Generates 5-9 control points around a circle with hash-derived
+// radius jitter, then connects them with smooth cubic beziers.
+
+export const drawBlob: DrawFunction = (ctx, size, config) => {
+  const rng: () => number = config?.rng ?? Math.random;
+  const r = size / 2;
+  const numPoints = 5 + Math.floor(rng() * 5); // 5-9 lobes
+  const points: Array<{ x: number; y: number }> = [];
+
+  for (let i = 0; i < numPoints; i++) {
+    const angle = (i / numPoints) * Math.PI * 2;
+    const jitter = 0.5 + rng() * 0.5; // radius varies 50-100%
+    points.push({
+      x: Math.cos(angle) * r * jitter,
+      y: Math.sin(angle) * r * jitter,
+    });
+  }
+
+  ctx.beginPath();
+  // Start at midpoint between last and first point
+  const last = points[points.length - 1];
+  const first = points[0];
+  ctx.moveTo((last.x + first.x) / 2, (last.y + first.y) / 2);
+
+  for (let i = 0; i < numPoints; i++) {
+    const curr = points[i];
+    const next = points[(i + 1) % numPoints];
+    const midX = (curr.x + next.x) / 2;
+    const midY = (curr.y + next.y) / 2;
+    ctx.quadraticCurveTo(curr.x, curr.y, midX, midY);
+  }
+  ctx.closePath();
+};
+
+// ── Ngon: irregular polygon with hash-controlled vertices ───────────
+// Vertex count 3-12, each vertex has independent radius jitter
+// producing irregular, organic polygons.
+
+export const drawNgon: DrawFunction = (ctx, size, config) => {
+  const rng: () => number = config?.rng ?? Math.random;
+  const r = size / 2;
+  const sides = 3 + Math.floor(rng() * 10); // 3-12 sides
+  const jitterAmount = 0.1 + rng() * 0.4; // 10-50% vertex displacement
+
+  ctx.beginPath();
+  for (let i = 0; i < sides; i++) {
+    const angle = (i / sides) * Math.PI * 2 - Math.PI / 2;
+    const radiusJitter = 1 - jitterAmount + rng() * jitterAmount * 2;
+    const x = Math.cos(angle) * r * radiusJitter;
+    const y = Math.sin(angle) * r * radiusJitter;
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+};
+
+// ── Lissajous: parametric curves with hash-derived frequency ratios ─
+// Produces figure-8s, knots, and complex looping curves.
+
+export const drawLissajous: DrawFunction = (ctx, size, config) => {
+  const rng: () => number = config?.rng ?? Math.random;
+  const r = size / 2;
+  // Frequency ratios — small integers produce recognizable patterns
+  const freqA = 1 + Math.floor(rng() * 5); // 1-5
+  const freqB = 1 + Math.floor(rng() * 5); // 1-5
+  const phase = rng() * Math.PI; // phase offset
+  const steps = 120;
+
+  ctx.beginPath();
+  for (let i = 0; i <= steps; i++) {
+    const t = (i / steps) * Math.PI * 2;
+    const x = Math.sin(freqA * t + phase) * r;
+    const y = Math.sin(freqB * t) * r;
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+};
+
+// ── Superellipse: |x|^n + |y|^n = 1 with hash-derived exponent ─────
+// n=2 is circle, n>2 is squircle, n<1 is astroid/star-like.
+
+export const drawSuperellipse: DrawFunction = (ctx, size, config) => {
+  const rng: () => number = config?.rng ?? Math.random;
+  const r = size / 2;
+  // Exponent range: 0.3 (spiky astroid) to 5 (rounded rectangle)
+  const n = 0.3 + rng() * 4.7;
+  const steps = 120;
+
+  ctx.beginPath();
+  for (let i = 0; i <= steps; i++) {
+    const t = (i / steps) * Math.PI * 2;
+    const cosT = Math.cos(t);
+    const sinT = Math.sin(t);
+    // Superellipse parametric form
+    const x = Math.sign(cosT) * Math.pow(Math.abs(cosT), 2 / n) * r;
+    const y = Math.sign(sinT) * Math.pow(Math.abs(sinT), 2 / n) * r;
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+};
+
+// ── Spirograph: hypotrochoid curves ─────────────────────────────────
+// Inner/outer radius ratios from hash produce unique looping patterns.
+
+export const drawSpirograph: DrawFunction = (ctx, size, config) => {
+  const rng: () => number = config?.rng ?? Math.random;
+  const scale = size / 2;
+  // R = outer radius, r = inner radius, d = pen distance from inner center
+  const R = 1;
+  const r = 0.2 + rng() * 0.6; // 0.2-0.8
+  const d = 0.3 + rng() * 0.7; // 0.3-1.0
+  // Number of full rotations needed to close the curve
+  const gcd = (a: number, b: number): number => {
+    const ai = Math.round(a * 1000);
+    const bi = Math.round(b * 1000);
+    const g = (x: number, y: number): number => (y === 0 ? x : g(y, x % y));
+    return g(ai, bi) / 1000;
+  };
+  const period = r / gcd(R, r);
+  const maxT = Math.min(period, 10) * Math.PI * 2; // cap at 10 rotations
+  const steps = Math.min(600, Math.floor(maxT * 20));
+
+  ctx.beginPath();
+  for (let i = 0; i <= steps; i++) {
+    const t = (i / steps) * maxT;
+    const x = ((R - r) * Math.cos(t) + d * Math.cos(((R - r) / r) * t)) * scale / (1 + d);
+    const y = ((R - r) * Math.sin(t) - d * Math.sin(((R - r) / r) * t)) * scale / (1 + d);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+};
+
+// ── Wave ring: concentric ring with sinusoidal displacement ─────────
+// Hash controls frequency, amplitude, and number of rings.
+
+export const drawWaveRing: DrawFunction = (ctx, size, config) => {
+  const rng: () => number = config?.rng ?? Math.random;
+  const r = size / 2;
+  const rings = 2 + Math.floor(rng() * 4); // 2-5 rings
+  const freq = 3 + Math.floor(rng() * 12); // 3-14 waves per ring
+  const amp = 0.05 + rng() * 0.15; // 5-20% of radius
+
+  ctx.beginPath();
+  for (let ring = 0; ring < rings; ring++) {
+    const baseR = r * (0.3 + (ring / rings) * 0.7);
+    const steps = 80;
+    for (let i = 0; i <= steps; i++) {
+      const t = (i / steps) * Math.PI * 2;
+      const wave = Math.sin(t * freq + ring * 1.5) * baseR * amp;
+      const x = Math.cos(t) * (baseR + wave);
+      const y = Math.sin(t) * (baseR + wave);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+  }
+};
+
+// ── Rose curve: polar rose r = cos(k*theta) ────────────────────────
+// k determines petal count. Integer k = k petals (odd) or 2k petals (even).
+
+export const drawRose: DrawFunction = (ctx, size, config) => {
+  const rng: () => number = config?.rng ?? Math.random;
+  const r = size / 2;
+  const k = 2 + Math.floor(rng() * 6); // 2-7 petal parameter
+  const steps = 200;
+
+  ctx.beginPath();
+  for (let i = 0; i <= steps; i++) {
+    const theta = (i / steps) * Math.PI * 2 * (k % 2 === 0 ? 1 : 2);
+    const rr = Math.cos(k * theta) * r;
+    const x = rr * Math.cos(theta);
+    const y = rr * Math.sin(theta);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+};
+
+
+// ── Shape registry ──────────────────────────────────────────────────
+
+export const proceduralShapes: Record<string, DrawFunction> = {
+  blob: drawBlob,
+  ngon: drawNgon,
+  lissajous: drawLissajous,
+  superellipse: drawSuperellipse,
+  spirograph: drawSpirograph,
+  waveRing: drawWaveRing,
+  rose: drawRose,
+};

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -23,6 +23,8 @@ import {
     jitterColor,
     desaturate,
     shiftTemperature,
+    luminance,
+    enforceContrast,
 } from "./canvas/colors";
 import {
     enhanceShapeGeneration,
@@ -67,6 +69,15 @@ const SACRED_SHAPES = [
   "torus",
   "eggOfLife",
 ];
+const PROCEDURAL_SHAPES = [
+  "blob",
+  "ngon",
+  "lissajous",
+  "superellipse",
+  "spirograph",
+  "waveRing",
+  "rose",
+];
 
 // ── Composition modes ───────────────────────────────────────────────
 
@@ -95,13 +106,15 @@ function pickShape(
   const basicW = 1 - layerRatio * 0.6;
   const complexW = 0.3 + layerRatio * 0.3;
   const sacredW = 0.1 + layerRatio * 0.4;
-  const total = basicW + complexW + sacredW;
+  const proceduralW = 0.25 + layerRatio * 0.2; // always present, grows with depth
+  const total = basicW + complexW + sacredW + proceduralW;
   const roll = rng() * total;
 
   let pool: string[];
   if (roll < basicW) pool = BASIC_SHAPES;
   else if (roll < basicW + complexW) pool = COMPLEX_SHAPES;
-  else pool = SACRED_SHAPES;
+  else if (roll < basicW + complexW + sacredW) pool = SACRED_SHAPES;
+  else pool = PROCEDURAL_SHAPES;
 
   const available = pool.filter((s) => shapeNames.includes(s));
   if (available.length === 0) {
@@ -339,6 +352,9 @@ export function renderHashArt(
   const bgRadius = Math.hypot(cx, cy);
   drawBackground(ctx, archetype.backgroundStyle, bgStart, bgEnd, width, height, cx, cy, bgRadius, rng, colors);
 
+  // Compute average background luminance for contrast enforcement
+  const bgLum = (luminance(bgStart) + luminance(bgEnd)) / 2;
+
   // ── 1b. Layered background (Feature G) ─────────────────────────
   // Draw large, very faint shapes to give the background texture
   const bgShapeCount = 3 + Math.floor(rng() * 4);
@@ -460,10 +476,10 @@ export function renderHashArt(
     const heroSize = adjustedMaxSize * (0.8 + rng() * 0.5);
     const heroRotation = rng() * 360;
     const heroFill = hexWithAlpha(
-      jitterColor(colors[Math.floor(rng() * colors.length)], rng, 0.05),
+      enforceContrast(jitterColor(colors[Math.floor(rng() * colors.length)], rng, 0.05), bgLum),
       0.15 + rng() * 0.2,
     );
-    const heroStroke = jitterColor(colors[Math.floor(rng() * colors.length)], rng, 0.05);
+    const heroStroke = enforceContrast(jitterColor(colors[Math.floor(rng() * colors.length)], rng, 0.05), bgLum);
 
     ctx.globalAlpha = 0.5 + rng() * 0.2;
     enhanceShapeGeneration(ctx, heroShape, heroFocal.x, heroFocal.y, {
@@ -559,8 +575,8 @@ export function renderHashArt(
         fillBase = shiftTemperature(fillBase, fgTempTarget, 0.15 + layerRatio * 0.1);
       }
 
-      const fillColor = jitterColor(fillBase, rng, 0.06);
-      const strokeColor = jitterColor(strokeBase, rng, 0.05);
+      const fillColor = enforceContrast(jitterColor(fillBase, rng, 0.06), bgLum);
+      const strokeColor = enforceContrast(jitterColor(strokeBase, rng, 0.05), bgLum);
 
       // Semi-transparent fill
       const fillAlpha = 0.2 + rng() * 0.5;
@@ -661,7 +677,7 @@ export function renderHashArt(
     const startWidth = (1 + rng() * 3) * scaleFactor;
 
     const lineColor = hexWithAlpha(
-      colors[Math.floor(rng() * colors.length)],
+      enforceContrast(colors[Math.floor(rng() * colors.length)], bgLum),
       0.4,
     );
     const lineAlpha = 0.06 + rng() * 0.1;
@@ -768,7 +784,7 @@ export function renderHashArt(
 
       ctx.globalAlpha = 0.06 + rng() * 0.1;
       ctx.strokeStyle = hexWithAlpha(
-        colors[Math.floor(rng() * colors.length)],
+        enforceContrast(colors[Math.floor(rng() * colors.length)], bgLum),
         0.3,
       );
 


### PR DESCRIPTION
## Summary

Two features addressing the core visual repetition and readability problems:

### 1. Procedural Shape Generators (7 new shapes)

The fixed shape library (24 shapes) means every hash picks from the same pool — you always see recognizable circles, hexagons, flowers of life, etc. Procedural shapes solve this by generating geometry from the hash itself, so every generation contains shapes that are unique to that hash.

| Shape | Algorithm | What the hash controls |
|-------|-----------|----------------------|
| **Blob** | Smooth closed curve via quadratic bezier through 5-9 control points | Number of lobes, radius jitter per lobe |
| **Ngon** | Irregular polygon with independent vertex displacement | Side count (3-12), vertex jitter (10-50%) |
| **Lissajous** | Parametric curve with frequency ratios | Frequencies a,b (1-5), phase offset |
| **Superellipse** | `\|x\|^n + \|y\|^n = 1` | Exponent: 0.3 (astroid) → 5 (squircle) |
| **Spirograph** | Hypotrochoid curves | Inner radius ratio, pen distance |
| **Wave Ring** | Concentric rings with sinusoidal displacement | Ring count, wave frequency, amplitude |
| **Rose** | Polar rose `r = cos(k*θ)` | Petal parameter k (2-7) |

Procedural shapes are a fourth category in the weighted shape picker alongside basic, complex, and sacred shapes.

### 2. Contrast Enforcement

Fixes the white-on-white readability problem where light palette modes (pastel-light, high-contrast) on light backgrounds (solid-light, radial-light) produce invisible shapes.

- Computes average background luminance after drawing the background
- Every foreground color (fills, strokes, hero shape, flow lines, connecting curves) is checked against the background
- Colors below the minimum contrast threshold are darkened+saturated (on light backgrounds) or lightened+saturated (on dark backgrounds)
- Uses sRGB relative luminance (WCAG formula)

### Also
- `enhanceShapeGeneration` now passes `rng` through to shape draw functions via config, ensuring procedural shapes maintain determinism
- ALGORITHM.md updated with both features

## Files changed
- `src/lib/canvas/shapes/procedural.ts` — new: 7 procedural shape generators
- `src/lib/canvas/shapes/index.ts` — register procedural shapes
- `src/lib/canvas/draw.ts` — pass rng to shape draw functions
- `src/lib/canvas/colors.ts` — luminance() and enforceContrast() utilities
- `src/lib/render.ts` — PROCEDURAL_SHAPES category, updated pickShape, contrast enforcement wiring
- `ALGORITHM.md` — documentation updates

## Testing
All 110 tests pass (21 new shape tests auto-discovered). Determinism preserved — same hash produces identical output.